### PR TITLE
Фиксы багов на `TableStoreFiledir`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
-# WIP 0.10.8
+# WIP 0.10.9
+* Column `filepath` is now written to meta-pseudo-df of `TableStoreFiledir` when `add_filepath_column` is enabled (https://github.com/epoch8/datapipe/pull/149)
+* Fix `TableStoreFiledir` issues with regular expressions: https://github.com/epoch8/datapipe/issues/146 и https://github.com/epoch8/datapipe/issues/147 (https://github.com/epoch8/datapipe/pull/149)
+
+# 0.10.8
 
 * Add `read_data` parameter to `TableStoreFiledir` (https://github.com/epoch8/datapipe/pull/132)
 * Fix fields order for compound indexes in `get_process_idx` (https://github.com/epoch8/datapipe/pull/136)
 * Add `check_for_changes` parameter to `DatatableTransform` step (https://github.com/epoch8/datapipe/pull/131)
 * Update `Pillow` to version `9.0.0`
-* Column `filepath` is now written to meta-pseudo-df of `TableStoreFiledir` when `add_filepath_column` is enabled (https://github.com/epoch8/datapipe/pull/149)
-* Fix `TableStoreFiledir` issues with regular expressions: https://github.com/epoch8/datapipe/issues/146 и https://github.com/epoch8/datapipe/issues/147 (https://github.com/epoch8/datapipe/pull/149)
-
 
 # 0.10.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 * Fix fields order for compound indexes in `get_process_idx` (https://github.com/epoch8/datapipe/pull/136)
 * Add `check_for_changes` parameter to `DatatableTransform` step (https://github.com/epoch8/datapipe/pull/131)
 * Update `Pillow` to version `9.0.0`
+* Column `filepath` is now written to meta-pseudo-df of `TableStoreFiledir` when `add_filepath_column` is enabled (https://github.com/epoch8/datapipe/pull/149)
+* Fix `TableStoreFiledir` issues with regular expressions: https://github.com/epoch8/datapipe/issues/146 и https://github.com/epoch8/datapipe/issues/147 (https://github.com/epoch8/datapipe/pull/149)
+
 
 # 0.10.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # WIP 0.10.9
 * Column `filepath` is now written to meta-pseudo-df of `TableStoreFiledir` when `add_filepath_column` is enabled (https://github.com/epoch8/datapipe/pull/149)
-* Fix `TableStoreFiledir` issues with regular expressions: https://github.com/epoch8/datapipe/issues/146 и https://github.com/epoch8/datapipe/issues/147 (https://github.com/epoch8/datapipe/pull/149)
+* Fix `TableStoreFiledir` issues with regular expressions: https://github.com/epoch8/datapipe/issues/146 and https://github.com/epoch8/datapipe/issues/147 (https://github.com/epoch8/datapipe/pull/149)
 
 # 0.10.8
 

--- a/datapipe/store/filedir.py
+++ b/datapipe/store/filedir.py
@@ -88,6 +88,7 @@ def _pattern_to_match(pat: str) -> str:
 
     pat = re.sub(r'\*\*?', r'([^/]+/)*[^/]+', pat)
     pat = re.sub(r'\{([^/]+?)\}', r'(?P<\1>[^/]+?)', pat)
+    pat = f"{pat}\\Z"
     return pat
 
 

--- a/tests/test_table_store.py
+++ b/tests/test_table_store.py
@@ -92,6 +92,18 @@ FILEDIR_DATA_PARAMS = [
     ),
     pytest.param(
         pd.DataFrame({
+            'id': [i for i in range(100)],
+            'name': [f'Product {i}' for i in range(100)],
+            'price': [1000 + i for i in range(100)],
+        }),
+        '{id}.json',
+        [
+            Column('id', String(100)),
+        ],
+        id='integer_id'
+    ),
+    pytest.param(
+        pd.DataFrame({
             'id1': [f'id_{i}' for i in range(100)],
             'id2': [f'id_{i}' for i in range(100)],
             'name': [f'Product {i}' for i in range(100)],
@@ -155,6 +167,38 @@ FILEDIR_DATA_PARAMS = [
             Column('id3', String(100)),
         ],
         id='columns_types'
+    ),
+    pytest.param(
+        pd.DataFrame({
+            'id1': [i for i in range(100)],
+            'id2': [i for i in range(100, 200)],
+            'name': [f'Product {i}' for i in range(100)],
+            'price': [1000 + i for i in range(100)],
+        }),
+        '{id1}/{id2}.json',
+        [
+            Column('id1', Integer),
+            Column('id2', Integer),
+        ],
+        id='multi_ids_slash'
+    ),
+    pytest.param(
+        pd.DataFrame({
+            'id1': [i for i in range(100)],
+            'id2': [i for i in range(100, 200)],
+            'id3': [i for i in range(100, 200)],
+            'id4': [i for i in range(100, 200)],
+            'name': [f'Product {i}' for i in range(100)],
+            'price': [1000 + i for i in range(100)],
+        }),
+        '{id1}/{id2}/{id3}/{id4}.json',
+        [
+            Column('id1', Integer),
+            Column('id2', String(100)),
+            Column('id3', Integer),
+            Column('id4', String(100)),
+        ],
+        id='multi_ids_slash2'
     )
 ]
 

--- a/tests/test_table_store.py
+++ b/tests/test_table_store.py
@@ -98,7 +98,7 @@ FILEDIR_DATA_PARAMS = [
         }),
         '{id}.json',
         [
-            Column('id', String(100)),
+            Column('id', Integer)
         ],
         id='integer_id'
     ),
@@ -172,20 +172,6 @@ FILEDIR_DATA_PARAMS = [
         pd.DataFrame({
             'id1': [i for i in range(100)],
             'id2': [i for i in range(100, 200)],
-            'name': [f'Product {i}' for i in range(100)],
-            'price': [1000 + i for i in range(100)],
-        }),
-        '{id1}/{id2}.json',
-        [
-            Column('id1', Integer),
-            Column('id2', Integer),
-        ],
-        id='multi_ids_slash'
-    ),
-    pytest.param(
-        pd.DataFrame({
-            'id1': [i for i in range(100)],
-            'id2': [i for i in range(100, 200)],
             'id3': [i for i in range(100, 200)],
             'id4': [i for i in range(100, 200)],
             'name': [f'Product {i}' for i in range(100)],
@@ -199,6 +185,18 @@ FILEDIR_DATA_PARAMS = [
             Column('id4', String(100)),
         ],
         id='multi_ids_slash2'
+    ),
+    pytest.param(
+        pd.DataFrame({
+            'id': ['json', 'json.', 'AAjson', 'AAAjsonBB.j', "assdjson.json", "jsonjson.jsonasdad.fdsds.json"],
+            'name': [f'Product {i}' for i in range(6)],
+            'price': [1000 + i for i in range(6)],
+        }),
+        '{id}.json',
+        [
+            Column('id', String(100)),
+        ],
+        id='complex_values'
     )
 ]
 


### PR DESCRIPTION
- Колонка `filepath` теперь записывается в метаданные при включенном `add_filepath_column=True`
- Пофиксил issues: https://github.com/epoch8/datapipe/issues/146 и https://github.com/epoch8/datapipe/issues/147 -- добавил токен `\Z` в конец шаблона + новый тест на это
- Добавил тесты на множественные ключи вида `{id}/{id2}.json`