### PR TITLE
Фикс: пустые `store` при `read_rows` и `read_rows_meta_pseudo_df` должны иметь primary ключи 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# WIP 0.10.10
+
+* Fix: `read_rows()` should return `DataFrame` with primary key columns even if empty
+
 # 0.10.9
 
 * Fix SettingWithCopyWarning in `MetaTable`

--- a/datapipe/store/filedir.py
+++ b/datapipe/store/filedir.py
@@ -260,9 +260,12 @@ class TableStoreFiledir(TableStore):
 
                     yield data
 
-        return pd.DataFrame.from_records(
+        df = pd.DataFrame.from_records(
             _gen()
         )
+        if df.empty:
+            df = pd.DataFrame(columns=self.primary_keys)
+        return df
 
     def read_rows_meta_pseudo_df(self, chunksize: int = 1000, run_config: RunConfig = None) -> Iterator[DataDF]:
         # FIXME реализовать чанкирование

--- a/datapipe/store/table_store.py
+++ b/datapipe/store/table_store.py
@@ -69,11 +69,11 @@ class TableDataSingleFileStore(TableStore):
 
                     return file_df.loc[idx.index].reset_index()
                 else:
-                    return pd.DataFrame()
+                    return pd.DataFrame(columns=self.primary_keys)
             else:
                 return file_df
         else:
-            return pd.DataFrame()
+            return pd.DataFrame(columns=self.primary_keys)
 
     def insert_rows(self, df: DataDF) -> None:
         if df.empty:

--- a/tests/test_table_store.py
+++ b/tests/test_table_store.py
@@ -234,7 +234,10 @@ def test_read_empty_df(store: TableStore, test_df: pd.DataFrame) -> None:
 
     df_empty = pd.DataFrame()
 
-    assert store.read_rows(cast(IndexDF, df_empty)).empty
+    # Empty df must have primary keys columns
+    df_result = store.read_rows(cast(IndexDF, df_empty))
+    assert df_result.empty
+    df_result[store.primary_keys]
 
 
 @parametrize_with_cases('store,test_df', cases=CasesTableStore, has_tag='supports_all_read_rows')

--- a/tests/test_table_store.py
+++ b/tests/test_table_store.py
@@ -234,10 +234,9 @@ def test_read_empty_df(store: TableStore, test_df: pd.DataFrame) -> None:
 
     df_empty = pd.DataFrame()
 
-    # Empty df must have primary keys columns
     df_result = store.read_rows(cast(IndexDF, df_empty))
     assert df_result.empty
-    df_result[store.primary_keys]
+    df_result[store.primary_keys]  # Empty df must have primary keys columns
 
 
 @parametrize_with_cases('store,test_df', cases=CasesTableStore, has_tag='supports_all_read_rows')
@@ -245,7 +244,9 @@ def test_insert_empty_df(store: TableStore, test_df: pd.DataFrame) -> None:
     df_empty = pd.DataFrame()
     store.insert_rows(df_empty)
 
-    assert store.read_rows().empty
+    df_result = store.read_rows()
+    assert df_result.empty
+    df_result[store.primary_keys]  # Empty df must have primary keys columns
 
 
 @parametrize_with_cases('store,test_df', cases=CasesTableStore, has_tag='supports_all_read_rows')
@@ -253,7 +254,9 @@ def test_update_empty_df(store: TableStore, test_df: pd.DataFrame) -> None:
     df_empty = pd.DataFrame()
     store.update_rows(df_empty)
 
-    assert store.read_rows().empty
+    df_result = store.read_rows()
+    assert df_result.empty
+    df_result[store.primary_keys]  # Empty df must have primary keys columns
 
 
 @parametrize_with_cases('store,test_df', cases=CasesTableStore)
@@ -312,6 +315,15 @@ def test_read_rows_meta_pseudo_df(store: TableStore, test_df: pd.DataFrame) -> N
 
 
 @parametrize_with_cases('store,test_df', cases=CasesTableStore)
+def test_read_empty_rows_meta_pseudo_df(store: TableStore, test_df: pd.DataFrame) -> None:
+    pseudo_df_iter = store.read_rows_meta_pseudo_df()
+    assert(isinstance(pseudo_df_iter, Iterable))
+    for pseudo_df in pseudo_df_iter:
+        assert(isinstance(pseudo_df, DataDF))
+        pseudo_df[store.primary_keys]  # Empty df must have primary keys columns
+
+
+@parametrize_with_cases('store,test_df', cases=CasesTableStore)
 def test_read_rows_meta_pseudo_df_with_runconfig(store: TableStore, test_df: pd.DataFrame) -> None:
     store.insert_rows(test_df)
 
@@ -319,6 +331,6 @@ def test_read_rows_meta_pseudo_df_with_runconfig(store: TableStore, test_df: pd.
 
     # TODO проверять, что runconfig реально влияет на результирующие данные
     pseudo_df_iter = store.read_rows_meta_pseudo_df(run_config=RunConfig(filters={'a': 1}))
-
     assert(isinstance(pseudo_df_iter, Iterable))
-    assert(isinstance(next(pseudo_df_iter), DataDF))
+    for pseudo_df in pseudo_df_iter:
+        assert(isinstance(pseudo_df, DataDF))


### PR DESCRIPTION
Этот фикс нужен в том случае, если при батчтрансформе по некоторых входам один вход может быть пустым без наличия соответствующих primary колонок, что в дальнейшем при pd.merge нужных таблиц вызывает ошибок.