### PR TITLE
Исправлена десериализация значений

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.11.6
+
+* Fix `RedisStore.read_rows`
+
 # 0.11.5
 
 * Force initialization of all tables in catalog in `build_compute`

--- a/datapipe/store/redis.py
+++ b/datapipe/store/redis.py
@@ -1,13 +1,14 @@
-from typing import Optional, Union, List
 import json
+from typing import List, Optional, Union
 
 import pandas as pd
 from redis.client import Redis
 from sqlalchemy import Column
 
-from datapipe.store.table_store import TableStore
 from datapipe.store.database import MetaKey
-from datapipe.types import DataDF, DataSchema, MetaSchema, IndexDF, data_to_index
+from datapipe.store.table_store import TableStore
+from datapipe.types import (DataDF, DataSchema, IndexDF, MetaSchema,
+                            data_to_index)
 
 
 def _serialize(values):

--- a/datapipe/store/redis.py
+++ b/datapipe/store/redis.py
@@ -66,10 +66,7 @@ class RedisStore(TableStore):
             keys = _to_itertuples(df_keys, self.prim_keys)
             keys_json = [_serialize(key) for key in keys]
             values = self.redis_connection.hmget(self.name, keys_json)
-            if values and values[-1] is not None:
-                values = [_deserialize(val) for val in values]
-            else:
-                values = []
+            values = [_deserialize(val) for val in values if val]
         else:
             pairs = self.redis_connection.hgetall(self.name)
             keys = [_deserialize(key) for key in pairs.keys()]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "datapipe-core"
-version = "0.11.5-post.1"
+version = "0.11.6"
 description = ""
 authors = ["Andrey Tatarinov <a@tatarinov.co>"]
 packages = [


### PR DESCRIPTION
Метод `hmget` у redis возвращает список значений по ключам. Если по какому-то ключу значения не нашлось, возвращается `None`
Соответственно в переменной `values` может оказаться список вида: `[None, значение, значение, None и т.д.]`
Старая конструкция if-else в таком случае не работает и код падает с ошибкой: `TypeError: the JSON object must be str, bytes or bytearray, not NoneType`
Этот PR исправляет эту ошибку