### PR TITLE
Fix missing columns in empty metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.11.8
+
+* Fix metadata columns in case of empty `get_metadata`
+
 # 0.11.7
 
 * Fix `DataTable.get_data` for large batches

--- a/datapipe/metastore.py
+++ b/datapipe/metastore.py
@@ -146,7 +146,7 @@ class MetaTable:
         if len(res) > 0:
             return cast(MetadataDF, pd.concat(res))
         else:
-            return cast(MetadataDF, pd.DataFrame(columns=self.primary_keys))
+            return cast(MetadataDF, pd.DataFrame(columns=[column.name for column in self.sql_schema]))
 
     def get_metadata_size(self, idx: IndexDF = None, include_deleted: bool = False) -> int:
         '''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "datapipe-core"
-version = "0.11.7"
+version = "0.11.8"
 description = ""
 authors = ["Andrey Tatarinov <a@tatarinov.co>"]
 packages = [


### PR DESCRIPTION
Исправляет пару мизорных ошибок, когда используется трансформация на пустых табличках

В частности, иногда падает вот на этой строке https://github.com/epoch8/datapipe/blob/1e414c25cf007730d5beae421d43d91c2eb22dec/datapipe/metastore.py#L267
(у таблички, получаемой через `get_metadata`, иногда нету колонок `hash` и `delete_ts`)