### PR TITLE
Add explicit output key mapping for batch transforms

### DIFF
--- a/.github/workflows/test_examples.yaml
+++ b/.github/workflows/test_examples.yaml
@@ -37,6 +37,7 @@ jobs:
           - many_to_zero
           - model_inference
           - one_to_many_pipeline
+          - key_mapping
         executor:
           - SingleThreadExecutor
           - RayExecutor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ See [key-mapping.md](design-docs/2025-12-key-mapping.md) for motivation
 * Renamed `JoinSpec` to `InputSpec`
 * Added `keys` parameter to `InputSpec` and `ComputeInput` to support
   joining tables with different key names
+* Added `OutputSpec` and `ComputeOutput.keys` to explicitly map transform keys
+  to output table primary keys
+* Fixed batch transform cleanup for aliased output keys and incomplete transform
+  keys
 
 ### Step name overrides and uniform hash-based naming
 

--- a/datapipe/cli.py
+++ b/datapipe/cli.py
@@ -324,7 +324,7 @@ def to_human_repr(step: ComputeStep, extra_args: dict | None = None) -> str:
         inputs = ", ".join(inputs_arr)
         res.append(f"  inputs: {inputs}")
 
-    if outputs_arr := [i.name for i in step.output_dts]:
+    if outputs_arr := [i.dt.name for i in step.output_dts]:
         outputs = ", ".join(outputs_arr)
         res.append(f"  outputs: {outputs}")
 

--- a/datapipe/compute.py
+++ b/datapipe/compute.py
@@ -18,7 +18,9 @@ from datapipe.types import (
     InputSpec,
     Labels,
     MetaSchema,
+    OutputSpec,
     PipelineInput,
+    PipelineOutput,
     Required,
     TableOrName,
 )
@@ -129,12 +131,51 @@ class ComputeInput:
             return self.dt.primary_schema
 
 
-def make_mungled_step_name(cls, base_name: str, input_dts: Sequence[ComputeInput], output_dts: list[DataTable]) -> str:
+@dataclass
+class ComputeOutput:
+    dt: DataTable
+
+    # If provided, this dict tells how transform keys map to output primary keys.
+    #
+    # Example: {"post_id": "id"} means that cleanup for transform key post_id
+    # should be applied to output primary key id.
+    keys: dict[str, str] | None = None
+
+    @property
+    def primary_keys(self) -> list[str]:
+        if self.keys:
+            return list(self.keys.keys())
+        else:
+            return self.dt.primary_keys
+
+    @property
+    def primary_schema(self) -> MetaSchema:
+        if self.keys:
+            primary_schema_dict = {col.name: col for col in self.dt.primary_schema}
+
+            schema = []
+            for k, accessor in self.keys.items():
+                source_column = primary_schema_dict[accessor]
+                schema.append(
+                    Column(
+                        k,
+                        source_column.type,
+                        primary_key=source_column.primary_key,
+                    )
+                )
+            return schema
+        else:
+            return self.dt.primary_schema
+
+
+def make_mungled_step_name(
+    cls, base_name: str, input_dts: Sequence[ComputeInput], output_dts: Sequence[ComputeOutput]
+) -> str:
     ss = [
         cls.__name__,
         base_name,
         *[i.dt.name for i in input_dts],
-        *[o.name for o in output_dts],
+        *[o.dt.name for o in output_dts],
     ]
 
     m = hashlib.shake_128()
@@ -160,6 +201,16 @@ def pipeline_input_to_compute_input(ds: DataStore, catalog: Catalog, input: Pipe
         return ComputeInput(dt=catalog.get_datatable(ds, input), join_type="full")
 
 
+def pipeline_output_to_compute_output(ds: DataStore, catalog: Catalog, output: PipelineOutput) -> ComputeOutput:
+    if isinstance(output, OutputSpec):
+        return ComputeOutput(
+            dt=catalog.get_datatable(ds, output.table),
+            keys=output.keys,
+        )
+
+    return ComputeOutput(dt=catalog.get_datatable(ds, output))
+
+
 class ComputeStep:
     """
     Шаг вычислений в графе вычислений.
@@ -179,18 +230,15 @@ class ComputeStep:
     def __init__(
         self,
         name: str,
-        input_dts: Sequence[ComputeInput | DataTable],
-        output_dts: list[DataTable],
+        input_dts: Sequence[ComputeInput],
+        output_dts: Sequence[ComputeOutput],
         labels: Labels | None = None,
         executor_config: ExecutorConfig | None = None,
     ) -> None:
-        # TODO validate name for database tables naming compatibility
         self.name = name
         # Нормализация input_dts: автоматически оборачиваем DataTable в ComputeInput
-        self.input_dts = [
-            inp if isinstance(inp, ComputeInput) else ComputeInput(dt=inp, join_type="full") for inp in input_dts
-        ]
-        self.output_dts = output_dts
+        self.input_dts = list(input_dts)
+        self.output_dts = list(output_dts)
         self._labels = labels
         self.executor_config = executor_config
 
@@ -207,7 +255,7 @@ class ComputeStep:
     # TODO: move to lints
     def validate(self) -> None:
         inp_p_keys_arr = [set(inp.dt.primary_keys) for inp in self.input_dts if inp]
-        out_p_keys_arr = [set(out.primary_keys) for out in self.output_dts if out]
+        out_p_keys_arr = [set(out.dt.primary_keys) for out in self.output_dts if out]
 
         inp_p_keys = set.intersection(*inp_p_keys_arr) if len(inp_p_keys_arr) else set()
         out_p_keys = set.intersection(*out_p_keys_arr) if len(out_p_keys_arr) else set()
@@ -222,7 +270,7 @@ class ComputeStep:
         key_to_column_type_out = {
             column.name: type(column.type)
             for inp in self.output_dts
-            for column in inp.primary_schema
+            for column in inp.dt.primary_schema
             if column.name in join_keys
         }
 
@@ -338,10 +386,10 @@ def run_steps(
 ) -> None:
     for step in steps:
         with tracer.start_as_current_span(
-            f"{step.name} {[i.dt.name for i in step.input_dts]} -> {[i.name for i in step.output_dts]}"
+            f"{step.name} {[i.dt.name for i in step.input_dts]} -> {[i.dt.name for i in step.output_dts]}"
         ):
             logger.info(
-                f"Running {step.name} {[i.dt.name for i in step.input_dts]} -> {[i.name for i in step.output_dts]}"
+                f"Running {step.name} {[i.dt.name for i in step.input_dts]} -> {[i.dt.name for i in step.output_dts]}"
             )
 
             step.run_full(ds=ds, run_config=run_config, executor=executor)
@@ -388,11 +436,11 @@ def run_steps_changelist(
             with tracer.start_as_current_span("run_steps"):
                 for step in steps:
                     with tracer.start_as_current_span(
-                        f"{step.name} {[i.dt.name for i in step.input_dts]} -> {[i.name for i in step.output_dts]}"
+                        f"{step.name} {[i.dt.name for i in step.input_dts]} -> {[i.dt.name for i in step.output_dts]}"
                     ):
                         logger.info(
                             f"Running {step.name} "
-                            f"{[i.dt.name for i in step.input_dts]} -> {[i.name for i in step.output_dts]}"
+                            f"{[i.dt.name for i in step.input_dts]} -> {[i.dt.name for i in step.output_dts]}"
                         )
 
                         if isinstance(step, BaseBatchTransformStep):

--- a/datapipe/meta/base.py
+++ b/datapipe/meta/base.py
@@ -8,8 +8,8 @@ from datapipe.run_config import RunConfig
 from datapipe.types import ChangeList, DataSchema, HashDF, IndexDF, MetadataDF, MetaSchema
 
 if TYPE_CHECKING:
-    from datapipe.compute import ComputeInput
-    from datapipe.datatable import DataStore, DataTable
+    from datapipe.compute import ComputeInput, ComputeOutput
+    from datapipe.datatable import DataStore
 
 
 class MetaPlane:
@@ -37,7 +37,7 @@ class MetaPlane:
         self,
         name: str,
         input_dts: Sequence["ComputeInput"],
-        output_dts: Sequence["DataTable"],
+        output_dts: Sequence["ComputeOutput"],
         transform_keys: list[str] | None = None,
         order_by: list[str] | None = None,
         order: Literal["asc", "desc"] = "asc",
@@ -200,8 +200,8 @@ class TransformMeta:
     @classmethod
     def compute_transform_schema(
         cls,
-        input_cis: Sequence["ComputeInput"],
-        output_dts: Sequence["DataTable"],
+        inputs: Sequence["ComputeInput"],
+        outputs: Sequence["ComputeOutput"],
         transform_keys: list[str] | None,
     ) -> tuple[list[str], MetaSchema]:
         # Hacky way to collect all the primary keys into a single set. Possible
@@ -209,24 +209,24 @@ class TransformMeta:
         # same key is defined differently in different input tables.
         all_keys: dict[str, Column] = {}
 
-        for ci in input_cis:
+        for ci in inputs:
             all_keys.update({col.name: col for col in ci.primary_schema})
 
-        for dt in output_dts:
-            all_keys.update({col.name: col for col in dt.primary_schema})
+        for co in outputs:
+            all_keys.update({col.name: col for col in co.primary_schema})
 
         if transform_keys is not None:
             return (transform_keys, [all_keys[k] for k in transform_keys])
 
-        assert len(input_cis) > 0, "At least one input table is required to infer transform keys"
+        assert len(inputs) > 0, "At least one input table is required to infer transform keys"
 
-        inp_p_keys = set.intersection(*[set(inp.primary_keys) for inp in input_cis])
+        inp_p_keys = set.intersection(*[set(inp.primary_keys) for inp in inputs])
         assert len(inp_p_keys) > 0
 
-        if len(output_dts) == 0:
+        if len(outputs) == 0:
             return (list(inp_p_keys), [all_keys[k] for k in inp_p_keys])
 
-        out_p_keys = set.intersection(*[set(out.primary_keys) for out in output_dts])
+        out_p_keys = set.intersection(*[set(out.primary_keys) for out in outputs])
         assert len(out_p_keys) > 0
 
         inp_out_p_keys = set.intersection(inp_p_keys, out_p_keys)

--- a/datapipe/meta/sql_meta.py
+++ b/datapipe/meta/sql_meta.py
@@ -16,8 +16,7 @@ import pandas as pd
 import sqlalchemy as sa
 from opentelemetry import trace
 
-from datapipe.compute import ComputeInput
-from datapipe.datatable import DataTable
+from datapipe.compute import ComputeInput, ComputeOutput
 from datapipe.meta.base import MetaPlane, TableDebugInfo, TableMeta, TransformMeta
 from datapipe.run_config import LabelDict, RunConfig
 from datapipe.sql_util import sql_apply_idx_filter_to_table, sql_apply_runconfig_filter
@@ -412,8 +411,8 @@ class SQLTransformMeta(TransformMeta):
         self,
         dbconn: DBConn,
         name: str,
-        input_cis: Sequence[ComputeInput],
-        output_dts: Sequence[DataTable],
+        inputs: Sequence[ComputeInput],
+        outputs: Sequence[ComputeOutput],
         transform_keys: list[str] | None,
         order_by: list[str] | None = None,
         order: Literal["asc", "desc"] = "asc",
@@ -422,12 +421,12 @@ class SQLTransformMeta(TransformMeta):
         self.dbconn = dbconn
         self.name = name
 
-        self.input_cis = input_cis
-        self.output_dts = output_dts
+        self.inputs = inputs
+        self.outputs = outputs
 
         self.transform_keys, self.transform_keys_schema = self.compute_transform_schema(
-            input_cis=self.input_cis,
-            output_dts=self.output_dts,
+            inputs=self.inputs,
+            outputs=self.outputs,
             transform_keys=transform_keys,
         )
 
@@ -452,8 +451,8 @@ class SQLTransformMeta(TransformMeta):
         return self.__class__, (
             self.dbconn,
             self.name,
-            self.input_cis,
-            self.output_dts,
+            self.inputs,
+            self.outputs,
             self.transform_keys,
             self.order_by,
             self.order,
@@ -480,7 +479,7 @@ class SQLTransformMeta(TransformMeta):
         run_config: RunConfig | None = None,
     ) -> tuple[int, Iterable[IndexDF]]:
         with tracer.start_as_current_span("compute ids to process"):
-            if len(self.input_cis) == 0:
+            if len(self.inputs) == 0:
                 return (0, iter([]))
 
             idx_count = self.get_changed_idx_count(
@@ -525,7 +524,7 @@ class SQLTransformMeta(TransformMeta):
         with tracer.start_as_current_span("compute ids to process"):
             changes = [pd.DataFrame(columns=self.transform_keys)]
 
-            for inp in self.input_cis:
+            for inp in self.inputs:
                 if inp.dt.name in change_list.changes:
                     idx = change_list.changes[inp.dt.name]
                     if any([key not in idx.columns for key in self.transform_keys]):
@@ -723,11 +722,11 @@ class SQLTransformMeta(TransformMeta):
         run_config: RunConfig | None = None,  # TODO remove
     ) -> Any:
         all_input_keys_counts: dict[str, int] = {}
-        for col in itertools.chain(*[inp.dt.primary_schema for inp in self.input_cis]):
+        for col in itertools.chain(*[inp.dt.primary_schema for inp in self.inputs]):
             all_input_keys_counts[col.name] = all_input_keys_counts.get(col.name, 0) + 1
 
         inp_ctes = []
-        for inp in self.input_cis:
+        for inp in self.inputs:
             inp_meta = inp.dt.meta
             assert isinstance(inp_meta, SQLTableMeta)
 
@@ -923,7 +922,7 @@ class SQLMetaPlane(MetaPlane):
         self,
         name: str,
         input_dts: Sequence[ComputeInput],
-        output_dts: Sequence[DataTable],
+        output_dts: Sequence[ComputeOutput],
         transform_keys: list[str] | None = None,
         order_by: list[str] | None = None,
         order: Literal["asc", "desc"] = "asc",
@@ -931,8 +930,8 @@ class SQLMetaPlane(MetaPlane):
         return SQLTransformMeta(
             dbconn=self.dbconn,
             name=name,
-            input_cis=input_dts,
-            output_dts=output_dts,
+            inputs=input_dts,
+            outputs=output_dts,
             transform_keys=transform_keys,
             order_by=order_by,
             order=order,

--- a/datapipe/step/batch_generate.py
+++ b/datapipe/step/batch_generate.py
@@ -7,7 +7,14 @@ from typing import Callable, Iterator
 import pandas as pd
 from opentelemetry import trace
 
-from datapipe.compute import Catalog, ComputeInput, ComputeStep, PipelineStep, make_mungled_step_name
+from datapipe.compute import (
+    Catalog,
+    ComputeInput,
+    ComputeStep,
+    PipelineStep,
+    make_mungled_step_name,
+    pipeline_output_to_compute_output,
+)
 from datapipe.datatable import DataStore, DataTable
 from datapipe.run_config import RunConfig
 from datapipe.step.datatable_transform import (
@@ -94,7 +101,7 @@ class BatchGenerate(PipelineStep):
 
     def build_compute(self, ds: DataStore, catalog: Catalog) -> list[ComputeStep]:
         input_dts: list[ComputeInput] = []
-        output_dts = [catalog.get_datatable(ds, name) for name in self.outputs]
+        output_dts = [pipeline_output_to_compute_output(ds, catalog, output) for output in self.outputs]
 
         step_name = self.name or make_mungled_step_name(
             DatatableTransformStep, self.func.__name__, input_dts, output_dts

--- a/datapipe/step/batch_transform.py
+++ b/datapipe/step/batch_transform.py
@@ -12,17 +12,20 @@ from typing import (
     Sequence,
 )
 
+import pandas as pd
 from opentelemetry import trace
 from tqdm_loggable.auto import tqdm
 
 from datapipe.compute import (
     Catalog,
     ComputeInput,
+    ComputeOutput,
     ComputeStep,
     PipelineStep,
     StepStatus,
     make_mungled_step_name,
     pipeline_input_to_compute_input,
+    pipeline_output_to_compute_output,
 )
 from datapipe.datatable import DataStore, DataTable
 from datapipe.executor import Executor, ExecutorConfig, SingleThreadExecutor
@@ -32,7 +35,9 @@ from datapipe.types import (
     DataDF,
     IndexDF,
     Labels,
+    OutputSpec,
     PipelineInput,
+    PipelineOutput,
     TableOrName,
     TransformResult,
 )
@@ -67,8 +72,8 @@ class BaseBatchTransformStep(ComputeStep):
         self,
         ds: DataStore,
         name: str,
-        input_dts: Sequence[ComputeInput | DataTable],
-        output_dts: list[DataTable],
+        input_dts: Sequence[ComputeInput],
+        output_dts: Sequence[ComputeOutput],
         transform_keys: list[str] | None = None,
         chunk_size: int = 1000,
         labels: Labels | None = None,
@@ -77,26 +82,16 @@ class BaseBatchTransformStep(ComputeStep):
         order_by: list[str] | None = None,
         order: Literal["asc", "desc"] = "asc",
     ) -> None:
-        # Support both old API (List[DataTable]) and new API (List[ComputeInput])
-        # Convert to new API format
-        compute_input_dts: list[ComputeInput] = []
-        for inp in input_dts:
-            if isinstance(inp, ComputeInput):
-                # New API: ComputeInput with .dt attribute
-                compute_input_dts.append(inp)
-            else:
-                # Old API: DataTable passed directly - convert to new API
-                compute_input_dts.append(ComputeInput(dt=inp, join_type="full"))
-
         ComputeStep.__init__(
             self,
             name=name,
-            input_dts=compute_input_dts,
+            input_dts=input_dts,
             output_dts=output_dts,
             labels=labels,
             executor_config=executor_config,
         )
 
+        self.output_specs = output_dts
         self.chunk_size = chunk_size
 
         # Force transform_keys to be a list, otherwise Pandas will not be happy
@@ -117,6 +112,33 @@ class BaseBatchTransformStep(ComputeStep):
         self.filters = filters
         self.order_by = order_by
         self.order = order
+
+    # TODO consider making this method a property of ComputeOutput
+    # Also see TableMeta.transform_idx_to_table_idx for the same functionality
+    @staticmethod
+    def _transform_idx_to_output_idx(
+        idx: IndexDF,
+        output_spec: ComputeOutput,
+    ) -> IndexDF | None:
+        res_dt = output_spec.dt
+        output_to_transform_keys = {
+            output_key: transform_key for transform_key, output_key in (output_spec.keys or {}).items()
+        }
+        columns: dict[str, Any] = {}
+
+        for pk in res_dt.primary_keys:
+            if pk in idx.columns:
+                columns[pk] = idx[pk]
+                continue
+
+            transform_key = output_to_transform_keys.get(pk)
+            if transform_key is not None and transform_key in idx.columns:
+                columns[pk] = idx[transform_key]
+
+        if not columns:
+            return None
+
+        return IndexDF(pd.DataFrame(columns))
 
     def _apply_filters_to_run_config(self, run_config: RunConfig | None = None) -> RunConfig | None:
         if self.filters is None:
@@ -198,12 +220,13 @@ class BaseBatchTransformStep(ComputeStep):
                     assert len(self.output_dts) == 1
                     output_dfs = [output_dfs]
 
-                for k, res_dt in enumerate(self.output_dts):
+                for k, output_spec in enumerate(self.output_specs):
+                    res_dt = output_spec.dt
                     # Берем k-ое значение функции для k-ой таблички
                     # Добавляем результат в результирующие чанки
                     change_idx = res_dt.store_chunk(
                         data_df=output_dfs[k],
-                        processed_idx=idx,
+                        processed_idx=self._transform_idx_to_output_idx(idx, output_spec),
                         now=process_ts,
                         run_config=run_config,
                     )
@@ -212,8 +235,13 @@ class BaseBatchTransformStep(ComputeStep):
 
         else:
             with tracer.start_as_current_span("delete missing data from output"):
-                for k, res_dt in enumerate(self.output_dts):
-                    del_idx = res_dt.meta.get_existing_idx(idx)
+                for k, output_spec in enumerate(self.output_specs):
+                    res_dt = output_spec.dt
+                    processed_idx = self._transform_idx_to_output_idx(idx, output_spec)
+                    if processed_idx is None:
+                        continue
+
+                    del_idx = res_dt.meta.get_existing_idx(processed_idx)
 
                     res_dt.delete_by_idx(del_idx, run_config=run_config)
 
@@ -418,7 +446,7 @@ class DatatableBatchTransform(PipelineStep):
 
     def build_compute(self, ds: DataStore, catalog: Catalog) -> list[ComputeStep]:
         input_dts = [pipeline_input_to_compute_input(ds, catalog, input) for input in self.inputs]
-        output_dts = [catalog.get_datatable(ds, name) for name in self.outputs]
+        output_dts = [pipeline_output_to_compute_output(ds, catalog, output) for output in self.outputs]
 
         step_name = self.name or make_mungled_step_name(
             DatatableBatchTransformStep, self.func.__name__, input_dts, output_dts
@@ -445,8 +473,8 @@ class DatatableBatchTransformStep(BaseBatchTransformStep):
         ds: DataStore,
         name: str,
         func: DatatableBatchTransformFunc,
-        input_dts: list[ComputeInput],
-        output_dts: list[DataTable],
+        input_dts: Sequence[ComputeInput],
+        output_dts: Sequence[ComputeOutput],
         kwargs: dict | None = None,
         transform_keys: list[str] | None = None,
         chunk_size: int = 1000,
@@ -484,7 +512,7 @@ class DatatableBatchTransformStep(BaseBatchTransformStep):
 class BatchTransform(PipelineStep):
     func: BatchTransformFunc
     inputs: list[PipelineInput]
-    outputs: list[TableOrName]
+    outputs: list[PipelineOutput]
     chunk_size: int = 1000
     name: str | None = None
     kwargs: dict[str, Any] | None = None
@@ -497,7 +525,7 @@ class BatchTransform(PipelineStep):
 
     def build_compute(self, ds: DataStore, catalog: Catalog) -> list[ComputeStep]:
         input_dts = [pipeline_input_to_compute_input(ds, catalog, input) for input in self.inputs]
-        output_dts = [catalog.get_datatable(ds, name) for name in self.outputs]
+        output_dts = [pipeline_output_to_compute_output(ds, catalog, output) for output in self.outputs]
 
         step_name = self.name or make_mungled_step_name(BatchTransformStep, self.func.__name__, input_dts, output_dts)
 
@@ -526,8 +554,8 @@ class BatchTransformStep(BaseBatchTransformStep):
         ds: DataStore,
         name: str,
         func: BatchTransformFunc,
-        input_dts: list[ComputeInput],
-        output_dts: list[DataTable],
+        input_dts: Sequence[ComputeInput],
+        output_dts: Sequence[ComputeOutput],
         kwargs: dict[str, Any] | None = None,
         transform_keys: list[str] | None = None,
         chunk_size: int = 1000,

--- a/datapipe/step/datatable_transform.py
+++ b/datapipe/step/datatable_transform.py
@@ -4,7 +4,16 @@ from typing import Any, Protocol
 
 from opentelemetry import trace
 
-from datapipe.compute import Catalog, ComputeInput, ComputeStep, PipelineStep, make_mungled_step_name
+from datapipe.compute import (
+    Catalog,
+    ComputeInput,
+    ComputeOutput,
+    ComputeStep,
+    PipelineStep,
+    make_mungled_step_name,
+    pipeline_input_to_compute_input,
+    pipeline_output_to_compute_output,
+)
 from datapipe.datatable import DataStore, DataTable
 from datapipe.executor import Executor
 from datapipe.run_config import RunConfig
@@ -32,7 +41,7 @@ class DatatableTransformStep(ComputeStep):
         self,
         name: str,
         input_dts: list[ComputeInput],
-        output_dts: list[DataTable],
+        output_dts: list[ComputeOutput],
         func: DatatableTransformFunc,
         kwargs: dict | None = None,
         check_for_changes: bool = True,
@@ -76,7 +85,7 @@ class DatatableTransformStep(ComputeStep):
                 self.func(
                     ds=ds,
                     input_dts=[inp.dt for inp in self.input_dts],
-                    output_dts=self.output_dts,
+                    output_dts=[out.dt for out in self.output_dts],
                     run_config=run_config,
                     kwargs=self.kwargs,
                 )
@@ -97,8 +106,8 @@ class DatatableTransform(PipelineStep):
     labels: Labels | None = None
 
     def build_compute(self, ds: DataStore, catalog: Catalog) -> list["ComputeStep"]:
-        input_dts = [ComputeInput(dt=catalog.get_datatable(ds, i), join_type="full") for i in self.inputs]
-        output_dts = [catalog.get_datatable(ds, i) for i in self.outputs]
+        input_dts = [pipeline_input_to_compute_input(ds, catalog, i) for i in self.inputs]
+        output_dts = [pipeline_output_to_compute_output(ds, catalog, i) for i in self.outputs]
 
         step_name = make_mungled_step_name(DatatableTransformStep, self.func.__name__, input_dts, output_dts)
 

--- a/datapipe/step/update_external_table.py
+++ b/datapipe/step/update_external_table.py
@@ -4,7 +4,14 @@ import time
 import pandas as pd
 from tqdm_loggable.auto import tqdm
 
-from datapipe.compute import Catalog, ComputeInput, ComputeStep, PipelineStep, make_mungled_step_name
+from datapipe.compute import (
+    Catalog,
+    ComputeInput,
+    ComputeStep,
+    PipelineStep,
+    make_mungled_step_name,
+    pipeline_output_to_compute_output,
+)
 from datapipe.datatable import DataStore, DataTable
 from datapipe.run_config import RunConfig
 from datapipe.step.datatable_transform import (
@@ -69,11 +76,12 @@ class UpdateExternalTable(PipelineStep):
         ):
             return update_external_table(ds, output_dts[0], run_config)
 
-        output_table = catalog.get_datatable(ds, self.output_table_name)
         input_dts: list[ComputeInput] = []
-        output_dts = [output_table]
+        output_dts = [pipeline_output_to_compute_output(ds, catalog, self.output_table_name)]
 
-        step_name = make_mungled_step_name(DatatableTransformStep, f"update_{output_table.name}", input_dts, output_dts)
+        step_name = make_mungled_step_name(
+            DatatableTransformStep, f"update_{self.output_table_name}", input_dts, output_dts
+        )
 
         return [
             DatatableTransformStep(

--- a/datapipe/types.py
+++ b/datapipe/types.py
@@ -76,6 +76,20 @@ PipelineInput = TableOrName | InputSpec
 
 
 @dataclass
+class OutputSpec:
+    table: TableOrName
+
+    # If provided, this dict tells how transform keys map to output primary keys.
+    #
+    # Example: {"post_id": "id"} means that cleanup for transform key post_id
+    # should be applied to output primary key id.
+    keys: dict[str, str] | None = None
+
+
+PipelineOutput = TableOrName | OutputSpec
+
+
+@dataclass
 class ChangeList:
     changes: dict[str, IndexDF] = field(default_factory=lambda: cast(dict[str, IndexDF], {}))
 

--- a/design-docs/2025-12-key-mapping.md
+++ b/design-docs/2025-12-key-mapping.md
@@ -36,7 +36,10 @@ BatchTransform(
         # matches tr.sub_user_id = User.id
         InputSpec(User, keys={"sub_user_id": "id"}),
     ],
-    outputs=[...],
+    outputs=[
+        # output table has user_id as PK; transform key sub_user_id is not relevant here
+        OutputSpec(SubscriptionUserSummary, keys={"user_id": "user_id"}),
+    ],
 )
 ```
 
@@ -49,18 +52,24 @@ And `process_func` at each execution will receive three dataframes:
 Both `user_df` and `sub_user_df` have columns aligned with `User` table, i.e.
 without renamings, it is up to end user to interpret the data.
 
-# InputSpec
+# InputSpec and OutputSpec
 
-We introduce `InputSpec` qualifier for `BatchTransform` inputs.
+We introduce `InputSpec` qualifier for `BatchTransform` inputs and `OutputSpec`
+qualifier for `BatchTransform` outputs.
 
-`keys` parameter defines which columns to use for this input table and where to
-get them from. `keys` is a dict in a form `{"{transform_key}": "meta_table_col"}`,
-where `meta_table_col` is a string referencing a column from the meta table
-(i.e. a primary key column).
+`InputSpec.keys` defines which columns to use for this input table and where to
+get them from. `keys` is a dict in a form `{"{transform_key}": "table_pk_col"}`,
+where `table_pk_col` is a string referencing a primary key column of the table.
 
-If table is provided as is without `InputSpec` wrapper, then it is equivalent to
+If a table is provided as is without `InputSpec` wrapper, then it is equivalent to
 `InputSpec(Table, join_type="outer", keys={"id1": "id1", ...})`, join type is
 outer join and all keys are mapped to themselves.
+
+`OutputSpec.keys` defines how transform keys map to the output table's primary key
+columns for the purpose of cleanup. `keys` is a dict in the form
+`{"{transform_key}": "output_pk_col"}`. Only the transform keys that are relevant
+to this output table need to be listed. If a table is provided without `OutputSpec`,
+all transform keys are assumed to match the output primary keys by name.
 
 Note: transform key columns must always be primary keys in the table schema.
 
@@ -71,23 +80,34 @@ Note: transform key columns must always be primary keys in the table schema.
 
 * [x] `datapipe.types.JoinSpec` is renamed to `InputSpec` and receives `keys`
   parameter
+* [x] `datapipe.types.OutputSpec` is added with `keys` parameter to map transform
+  keys to output table primary key columns
 
 ## Compute
 
 * [x] `datapipe.compute.ComputeInput` receives `keys` parameter
+* [x] `datapipe.compute.ComputeOutput` is added with `keys` parameter (mirrors
+  `ComputeInput`); `pipeline_output_to_compute_output` converts `PipelineOutput`
+  to `ComputeOutput`
+
+`datapipe.meta.base.TableMeta` (base class, not `SQLTableMeta`):
+* [x] new method `transform_idx_to_table_idx` which should be used to convert
+  transform keys to table keys by applying `keys` aliasing
 
 `datapipe.meta.sql_meta.SQLTableMeta`:
-* [x] new method `transform_idx_to_table_idx` which should be used to convert
-  transform keys to table keys
 * [x] `get_agg_cte` receives `keys` parameter and starts producing subquery with
   renamed keys
 * [ ] `get_agg_cte` correctly applies `keys` to `filter_idx` parameter
 * [ ] `get_agg_cte` correctly applies `keys` to `RunConfig` filters
 
-`BatchTransform`:
-* [x] correctly converts transform idx to table idx in `get_batch_input_dfs`
-* [x] inputs and outputs are stored as `ComputeInput` lists
+`BatchTransformStep`:
+* [x] correctly converts transform idx to table idx in `get_batch_input_dfs` via
+  `transform_idx_to_table_idx`
+* [x] new method `_transform_idx_to_output_idx` converts transform idx to output
+  table idx using `ComputeOutput.keys` for cleanup/delete operations
+* [x] inputs are stored as `ComputeInput` list; outputs are stored as `ComputeOutput`
+  list
 
 `DataTable`:
 * [x] `DataTable.get_data` accepts `table_idx` which is acquired by applying
-  `tranform_idx_to_table_idx`
+  `transform_idx_to_table_idx`

--- a/examples/key_mapping/.gitignore
+++ b/examples/key_mapping/.gitignore
@@ -1,0 +1,1 @@
+db.sqlite

--- a/examples/key_mapping/app.py
+++ b/examples/key_mapping/app.py
@@ -1,0 +1,154 @@
+"""
+Key mapping example: joining tables whose primary keys don't share the same column name.
+
+Schema
+------
+  authors (id PK, name)
+  posts   (id PK, author_id, title, body)
+
+Both tables use `id` as their primary key, so a plain BatchTransform would not
+know how to join them — the transform engine would see two unrelated `id` columns.
+
+InputSpec.keys lets you give each table's primary key a *transform-level* alias,
+creating a common coordinate space ("post_id" / "author_id") that the engine uses
+to schedule work and match rows.
+
+OutputSpec.keys does the symmetric thing on the output side: it tells the engine
+which output primary key column corresponds to which transform key, so cleanup
+(deletes / invalidations) stays correct when posts or authors are removed.
+
+Result tables
+-------------
+  post_cards (id PK, title, author_name)   — one enriched card per post
+"""
+
+import pandas as pd
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+from datapipe.compute import Catalog, DatapipeApp, Pipeline
+from datapipe.datatable import DataStore
+from datapipe.step.batch_generate import BatchGenerate
+from datapipe.step.batch_transform import BatchTransform
+from datapipe.store.database import DBConn
+from datapipe.types import InputSpec, OutputSpec
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class Author(Base):
+    __tablename__ = "authors"
+
+    id: Mapped[str] = mapped_column(primary_key=True)
+    name: Mapped[str]
+
+
+class Post(Base):
+    __tablename__ = "posts"
+
+    # Composite PK: posts are scoped to an author.
+    # Both columns must be PKs so the meta table can track them for scheduling.
+    id: Mapped[str] = mapped_column(primary_key=True)
+    author_id: Mapped[str] = mapped_column(primary_key=True)
+    title: Mapped[str]
+    body: Mapped[str]
+
+
+class PostCard(Base):
+    __tablename__ = "post_cards"
+
+    # Primary key is named `id` here, but it stores the *post* id.
+    # OutputSpec.keys tells the engine: transform key "post_id" → column "id".
+    id: Mapped[str] = mapped_column(primary_key=True)
+    title: Mapped[str]
+    author_name: Mapped[str]
+
+
+def generate_authors():
+    yield pd.DataFrame(
+        [
+            {"id": "a1", "name": "Alice"},
+            {"id": "a2", "name": "Bob"},
+        ]
+    )
+
+
+def generate_posts():
+    yield pd.DataFrame(
+        [
+            {"id": "p1", "author_id": "a1", "title": "Hello World", "body": "My first post."},
+            {"id": "p2", "author_id": "a1", "title": "Python Tips", "body": "Use list comprehensions."},
+            {"id": "p3", "author_id": "a2", "title": "Data Science 101", "body": "Start with the data."},
+        ]
+    )
+
+
+def enrich_posts(posts_df: pd.DataFrame, authors_df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Receives a chunk of posts (already filtered to the current task batch)
+    and the matching authors (joined via author_id).
+
+    Column names here are the *original* table column names, not the transform
+    aliases — InputSpec.keys only affects the scheduling join, not what you see
+    in the dataframe.
+    """
+    merged = posts_df.merge(authors_df, left_on="author_id", right_on="id", suffixes=("_post", "_author"))
+    return pd.DataFrame(
+        {
+            "id": merged["id_post"],
+            "title": merged["title"],
+            "author_name": merged["name"],
+        }
+    )
+
+
+pipeline = Pipeline(
+    [
+        BatchGenerate(generate_authors, outputs=[Author]),
+        BatchGenerate(generate_posts, outputs=[Post]),
+        BatchTransform(
+            enrich_posts,
+            # "post_id" and "author_id" are virtual transform-level keys.
+            # Each unique (post_id, author_id) pair is one unit of incremental work.
+            transform_keys=["post_id", "author_id"],
+            inputs=[
+                # Post.id    → transform key "post_id"
+                # Post.author_id → transform key "author_id"  (direct match by name would work
+                #                  here, but listed explicitly for clarity)
+                InputSpec(Post, keys={"post_id": "id", "author_id": "author_id"}),
+                # Author.id → transform key "author_id"
+                # Without this mapping the engine would try to join on a column named
+                # "author_id" in the authors meta table, which doesn't exist there.
+                InputSpec(Author, keys={"author_id": "id"}),
+            ],
+            outputs=[
+                # PostCard.id stores the post id, so transform key "post_id" → column "id".
+                # This ensures that when a post is deleted, the corresponding post_card row
+                # is also removed (the engine knows to look up post_card by id = post_id).
+                OutputSpec(PostCard, keys={"post_id": "id"}),
+            ],
+        ),
+    ]
+)
+
+
+dbconn = DBConn("sqlite+pysqlite3:///db.sqlite", sqla_metadata=Base.metadata)
+ds = DataStore(dbconn)
+app = DatapipeApp(ds, Catalog({}), pipeline)
+
+
+if __name__ == "__main__":
+    from datapipe.compute import run_steps
+
+    ds.meta_dbconn.sqla_metadata.create_all(ds.meta_dbconn.con)
+    run_steps(app.ds, app.steps)
+
+    # Show result
+    import sqlalchemy as sa
+
+    with dbconn.con.begin() as con:
+        rows = con.execute(sa.text("SELECT id, title, author_name FROM post_cards ORDER BY id")).fetchall()
+    print("\npost_cards:")
+    for row in rows:
+        print(f"  {row.id}: '{row.title}' by {row.author_name}")

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   db:
-    image: postgres:12
+    image: postgres:17
     ports:
       - 5432:5432
     environment:

--- a/tests/test_batch_transform_scheduling.py
+++ b/tests/test_batch_transform_scheduling.py
@@ -1,7 +1,7 @@
 import pandas as pd
 from sqlalchemy import Column, Integer
 
-from datapipe.compute import ComputeInput
+from datapipe.compute import ComputeInput, ComputeOutput
 from datapipe.datatable import DataStore
 from datapipe.step.batch_transform import BatchTransformStep
 from datapipe.store.database import TableStoreDB
@@ -40,7 +40,7 @@ def test_inc_process_proc_no_change(dbconn) -> None:
         input_dts=[
             ComputeInput(dt=tbl1, join_type="full"),
         ],
-        output_dts=[tbl2],
+        output_dts=[ComputeOutput(dt=tbl2)],
     )
 
     count, idx_gen = step.get_full_process_ids(ds)
@@ -150,7 +150,7 @@ def test_aux_input(dbconn) -> None:
             ComputeInput(dt=tbl_items2, join_type="full"),
             ComputeInput(dt=tbl_aux, join_type="full"),
         ],
-        output_dts=[tbl_out],
+        output_dts=[ComputeOutput(dt=tbl_out)],
         transform_keys=["id"],
     )
 

--- a/tests/test_complex_cross_merge_many_tables.py
+++ b/tests/test_complex_cross_merge_many_tables.py
@@ -12,6 +12,7 @@ from datapipe.step.batch_generate import BatchGenerate
 from datapipe.step.batch_transform import BatchTransform
 from datapipe.store.database import TableStoreDB
 from datapipe.tests.util import assert_datatable_equal
+from datapipe.types import InputSpec, OutputSpec
 
 TEST_SCHEMA_LEFT = [
     pytest.param(
@@ -90,8 +91,9 @@ def get_primary_key_to_their_tables(schemas: list[list[Column]], table_names: li
     primary_keys = [set([x.name for x in schema if x.primary_key]) for schema in schemas]
     idxs = range(len(schemas))
     pairs = itertools.combinations(idxs, 2)
-    nt = lambda a, b: primary_keys[a].intersection(primary_keys[b])
-    table_name1_table_name2_to_intersection_idxs = {(table_names[t[0]], table_names[t[1]]): nt(*t) for t in pairs}
+    table_name1_table_name2_to_intersection_idxs = {
+        (table_names[t[0]], table_names[t[1]]): primary_keys[t[0]].intersection(primary_keys[t[1]]) for t in pairs
+    }
     return table_name1_table_name2_to_intersection_idxs
 
 
@@ -245,3 +247,90 @@ def test_complex_cross_merge_on_many_tables(dbconn, test_case):
     for output_table_name, test_output_df in zip(output_tables_names, test_output_dfs):
         tbl_output = catalog.get_datatable(ds, output_table_name)
         assert_datatable_equal(tbl_output, test_output_df)
+
+
+def test_complex_cross_merge_on_many_tables_with_index_aliases(dbconn):
+    ds = DataStore(dbconn, create_meta_table=True)
+
+    left_schema = [
+        Column("id_left", Integer, primary_key=True),
+        Column("a_left", Integer),
+    ]
+    center_schema = [
+        Column("id_center", Integer, primary_key=True),
+        Column("c_center", Integer),
+    ]
+    right_schema = [
+        Column("id_right", Integer, primary_key=True),
+        Column("b_right", Integer),
+    ]
+    output_schema = [
+        Column("id_left", Integer, primary_key=True),
+        Column("id_center", Integer, primary_key=True),
+        Column("id_right", Integer, primary_key=True),
+        Column("a_left", Integer),
+        Column("c_center", Integer),
+        Column("b_right", Integer),
+    ]
+
+    test_df_left = pd.DataFrame({"id_left": [1, 2], "a_left": [10, 20]})
+    test_df_center = pd.DataFrame({"id_center": [3, 4], "c_center": [30, 40]})
+    test_df_right = pd.DataFrame({"id_right": [5, 6], "b_right": [50, 60]})
+    test_df_output = cross_merge_func(
+        test_df_left,
+        test_df_center,
+        test_df_right,
+        input_intersection_idxs=[],
+        output_schema_tables=[output_schema],
+    )[0]
+
+    catalog = Catalog(
+        {
+            "table_left": Table(store=TableStoreDB(dbconn, "table_left", left_schema, True)),
+            "table_center": Table(store=TableStoreDB(dbconn, "table_center", center_schema, True)),
+            "table_right": Table(store=TableStoreDB(dbconn, "table_right", right_schema, True)),
+            "table_output": Table(store=TableStoreDB(dbconn, "table_output", output_schema, True)),
+        }
+    )
+
+    def gen_tbl(df):
+        yield df
+
+    pipeline_case = Pipeline(
+        [
+            BatchGenerate(func=gen_tbl, outputs=["table_left"], kwargs=dict(df=test_df_left)),
+            BatchGenerate(func=gen_tbl, outputs=["table_center"], kwargs=dict(df=test_df_center)),
+            BatchGenerate(func=gen_tbl, outputs=["table_right"], kwargs=dict(df=test_df_right)),
+            BatchTransform(
+                func=cross_merge_func,
+                inputs=[
+                    InputSpec(table="table_left", keys={"left_id": "id_left"}),
+                    InputSpec(table="table_center", keys={"center_id": "id_center"}),
+                    InputSpec(table="table_right", keys={"right_id": "id_right"}),
+                ],
+                outputs=[
+                    OutputSpec(
+                        table="table_output",
+                        keys={
+                            "left_id": "id_left",
+                            "center_id": "id_center",
+                            "right_id": "id_right",
+                        },
+                    )
+                ],
+                transform_keys=["left_id", "center_id", "right_id"],
+                chunk_size=6,
+                kwargs=dict(
+                    input_intersection_idxs=[],
+                    output_schema_tables=[output_schema],
+                ),
+            ),
+        ]
+    )
+
+    run_pipeline(ds, catalog, pipeline_case)
+
+    assert_datatable_equal(catalog.get_datatable(ds, "table_left"), test_df_left)
+    assert_datatable_equal(catalog.get_datatable(ds, "table_center"), test_df_center)
+    assert_datatable_equal(catalog.get_datatable(ds, "table_right"), test_df_right)
+    assert_datatable_equal(catalog.get_datatable(ds, "table_output"), test_df_output)

--- a/tests/test_complex_cross_merge_two_tables.py
+++ b/tests/test_complex_cross_merge_two_tables.py
@@ -12,6 +12,7 @@ from datapipe.step.batch_generate import BatchGenerate
 from datapipe.step.batch_transform import BatchTransform
 from datapipe.store.database import TableStoreDB
 from datapipe.tests.util import assert_datatable_equal, assert_df_equal
+from datapipe.types import InputSpec, OutputSpec
 
 TEST_SCHEMA_LEFT = [
     pytest.param(
@@ -248,6 +249,66 @@ def test_complex_cross_merge_scenary(dbconn, test_case):
     assert_datatable_equal(tbl_left, test_df_left)
     assert_datatable_equal(tbl_right, test_df_right)
     assert_datatable_equal(tbl_left_x_right, test_df_left_x_right)
+
+
+def test_complex_cross_merge_scenary_with_index_aliases(dbconn):
+    ds = DataStore(dbconn, create_meta_table=True)
+
+    left_schema = [
+        Column("id_left", Integer, primary_key=True),
+        Column("a_left", Integer),
+    ]
+    right_schema = [
+        Column("id_right", Integer, primary_key=True),
+        Column("b_right", Integer),
+    ]
+    left_x_right_schema = left_schema + right_schema
+
+    test_df_left = pd.DataFrame({"id_left": [1, 2], "a_left": [10, 20]})
+    test_df_right = pd.DataFrame({"id_right": [3, 4], "b_right": [30, 40]})
+    test_df_left_x_right = cross_merge_func(test_df_left, test_df_right)
+
+    catalog = Catalog(
+        {
+            "tbl_left": Table(store=TableStoreDB(dbconn, "tbl_left", left_schema, True)),
+            "tbl_right": Table(store=TableStoreDB(dbconn, "tbl_right", right_schema, True)),
+            "tbl_left_x_right": Table(store=TableStoreDB(dbconn, "tbl_left_x_right", left_x_right_schema, True)),
+        }
+    )
+
+    def gen_tbl(df):
+        yield df
+
+    pipeline_case = Pipeline(
+        [
+            BatchGenerate(func=gen_tbl, outputs=["tbl_left"], kwargs=dict(df=test_df_left)),
+            BatchGenerate(func=gen_tbl, outputs=["tbl_right"], kwargs=dict(df=test_df_right)),
+            BatchTransform(
+                func=cross_merge_func,
+                inputs=[
+                    InputSpec(table="tbl_left", keys={"left_id": "id_left"}),
+                    InputSpec(table="tbl_right", keys={"right_id": "id_right"}),
+                ],
+                outputs=[
+                    OutputSpec(
+                        table="tbl_left_x_right",
+                        keys={
+                            "left_id": "id_left",
+                            "right_id": "id_right",
+                        },
+                    )
+                ],
+                transform_keys=["left_id", "right_id"],
+                chunk_size=6,
+            ),
+        ]
+    )
+
+    run_pipeline(ds, catalog, pipeline_case)
+
+    assert_datatable_equal(catalog.get_datatable(ds, "tbl_left"), test_df_left)
+    assert_datatable_equal(catalog.get_datatable(ds, "tbl_right"), test_df_right)
+    assert_datatable_equal(catalog.get_datatable(ds, "tbl_left_x_right"), test_df_left_x_right)
 
 
 def reverse_cross_merge_func(df_left_x_right: pd.DataFrame, left_schema: list[Column], right_schema: list[Column]):

--- a/tests/test_complex_pipeline.py
+++ b/tests/test_complex_pipeline.py
@@ -11,7 +11,7 @@ from datapipe.step.batch_generate import BatchGenerate
 from datapipe.step.batch_transform import BatchTransform
 from datapipe.store.database import TableStoreDB
 from datapipe.tests.util import assert_datatable_equal, assert_df_equal
-from datapipe.types import IndexDF, Required
+from datapipe.types import IndexDF, InputSpec, OutputSpec, Required
 
 TEST__ITEM = pd.DataFrame(
     {
@@ -155,6 +155,127 @@ def test_complex_pipeline(dbconn):
     )
     run_steps(ds, steps)
     assert_datatable_equal(ds.get_table("output"), TEST_RESULT)
+
+
+def test_complex_pipeline_with_index_aliases(dbconn):
+    ds = DataStore(dbconn, create_meta_table=True)
+    catalog = Catalog(
+        {
+            "item": Table(
+                store=TableStoreDB(
+                    dbconn,
+                    "item",
+                    [
+                        Column("item_id", String, primary_key=True),
+                        Column("item__attribute", String),
+                    ],
+                    True,
+                )
+            ),
+            "pipeline": Table(
+                store=TableStoreDB(
+                    dbconn,
+                    "pipeline",
+                    [
+                        Column("pipeline_id", String, primary_key=True),
+                        Column("pipeline__attribute", String),
+                    ],
+                    True,
+                )
+            ),
+            "prediction": Table(
+                store=TableStoreDB(
+                    dbconn,
+                    "prediction",
+                    [
+                        Column("item_id", String, primary_key=True),
+                        Column("pipeline_id", String, primary_key=True),
+                        Column("keypoint_name", String, primary_key=True),
+                        Column("prediction__attribute", String),
+                    ],
+                    True,
+                )
+            ),
+            "keypoint": Table(
+                store=TableStoreDB(
+                    dbconn,
+                    "keypoint",
+                    [
+                        Column("keypoint_id", Integer, primary_key=True),
+                        Column("keypoint_name", String, primary_key=True),
+                    ],
+                    True,
+                )
+            ),
+            "output": Table(
+                store=TableStoreDB(
+                    dbconn,
+                    "output",
+                    [
+                        Column("item_id", String, primary_key=True),
+                        Column("pipeline_id", String, primary_key=True),
+                        Column("attirbute", String),
+                    ],
+                    True,
+                )
+            ),
+        }
+    )
+
+    def complex_function(df__item, df__pipeline, df__prediction, df__keypoint, idx: IndexDF):
+        assert idx[idx[["post_item_id", "post_pipeline_id"]].duplicated()].empty
+        assert len(df__keypoint) == len(TEST__KEYPOINT)
+        df__output = pd.merge(df__item, df__prediction, on=["item_id"])
+        df__output = pd.merge(df__output, df__pipeline, on=["pipeline_id"])
+        df__output = pd.merge(df__output, df__keypoint, on=["keypoint_name"])
+        df__output = df__output[["item_id", "pipeline_id"]].drop_duplicates()
+        df__output["attirbute"] = "attribute"
+        return df__output
+
+    pipeline = Pipeline(
+        [
+            BatchTransform(
+                func=complex_function,
+                inputs=[
+                    InputSpec(table="item", keys={"post_item_id": "item_id"}),
+                    InputSpec(table="pipeline", keys={"post_pipeline_id": "pipeline_id"}),
+                    InputSpec(
+                        table="prediction",
+                        keys={
+                            "post_item_id": "item_id",
+                            "post_pipeline_id": "pipeline_id",
+                        },
+                    ),
+                    "keypoint",
+                ],
+                outputs=[
+                    OutputSpec(
+                        table="output",
+                        keys={
+                            "post_item_id": "item_id",
+                            "post_pipeline_id": "pipeline_id",
+                        },
+                    )
+                ],
+                transform_keys=["post_item_id", "post_pipeline_id"],
+                chunk_size=50,
+            ),
+        ]
+    )
+    steps = build_compute(ds, catalog, pipeline)
+    ds.get_table("item").store_chunk(TEST__ITEM)
+    ds.get_table("pipeline").store_chunk(TEST__PIPELINE)
+    ds.get_table("prediction").store_chunk(TEST__PREDICTION)
+    ds.get_table("keypoint").store_chunk(TEST__KEYPOINT)
+    test_result = complex_function(
+        TEST__ITEM,
+        TEST__PIPELINE,
+        TEST__PREDICTION,
+        TEST__KEYPOINT,
+        idx=cast(IndexDF, pd.DataFrame(columns=["post_item_id", "post_pipeline_id"])),
+    )
+    run_steps(ds, steps)
+    assert_datatable_equal(ds.get_table("output"), test_result)
 
 
 TEST__FROZEN_DATASET = pd.DataFrame(

--- a/tests/test_core_steps1.py
+++ b/tests/test_core_steps1.py
@@ -8,7 +8,7 @@ import pytest
 from sqlalchemy import Column
 from sqlalchemy.sql.sqltypes import JSON, Integer
 
-from datapipe.compute import ComputeInput
+from datapipe.compute import ComputeInput, ComputeOutput
 from datapipe.datatable import DataStore
 from datapipe.step.batch_generate import do_batch_generate
 from datapipe.step.batch_transform import BatchTransformStep
@@ -99,7 +99,7 @@ def test_inc_process_modify_values(dbconn) -> None:
         name="test",
         func=id_func,
         input_dts=[ComputeInput(dt=tbl1, join_type="full")],
-        output_dts=[tbl2],
+        output_dts=[ComputeOutput(dt=tbl2)],
     )
 
     step.run_full(ds)
@@ -130,7 +130,7 @@ def test_inc_process_delete_values_from_input(dbconn) -> None:
         name="test",
         func=id_func,
         input_dts=[ComputeInput(dt=tbl1, join_type="full")],
-        output_dts=[tbl2],
+        output_dts=[ComputeOutput(dt=tbl2)],
     )
 
     step.run_full(ds)
@@ -165,7 +165,7 @@ def test_inc_process_delete_values_from_proc(dbconn) -> None:
         name="test",
         func=id_func,
         input_dts=[ComputeInput(dt=tbl1, join_type="full")],
-        output_dts=[tbl2],
+        output_dts=[ComputeOutput(dt=tbl2)],
     )
 
     step.run_full(ds)
@@ -224,7 +224,7 @@ def test_inc_process_many_modify_values(dbconn) -> None:
         name="step_inc",
         func=inc_func,
         input_dts=[ComputeInput(dt=tbl, join_type="full")],
-        output_dts=[tbl1, tbl2, tbl3],
+        output_dts=[ComputeOutput(dt=tbl1), ComputeOutput(dt=tbl2), ComputeOutput(dt=tbl3)],
     )
 
     step_inc.run_full(ds)
@@ -250,7 +250,7 @@ def test_inc_process_many_modify_values(dbconn) -> None:
         name="step_inc_inv",
         func=inc_func_inv,
         input_dts=[ComputeInput(dt=tbl, join_type="full")],
-        output_dts=[tbl3, tbl2, tbl1],
+        output_dts=[ComputeOutput(dt=tbl3), ComputeOutput(dt=tbl2), ComputeOutput(dt=tbl1)],
     )
 
     step_inc_inv.run_full(ds)
@@ -306,7 +306,7 @@ def test_inc_process_many_several_inputs(dbconn) -> None:
             ComputeInput(dt=tbl1, join_type="full"),
             ComputeInput(dt=tbl2, join_type="full"),
         ],
-        output_dts=[tbl],
+        output_dts=[ComputeOutput(dt=tbl)],
     )
 
     step.run_full(ds)
@@ -390,7 +390,7 @@ def test_inc_process_many_several_outputs(dbconn) -> None:
         name="test",
         func=inc_func,
         input_dts=[ComputeInput(dt=tbl, join_type="full")],
-        output_dts=[tbl_good, tbl_bad],
+        output_dts=[ComputeOutput(dt=tbl_good), ComputeOutput(dt=tbl_bad)],
     )
 
     step.run_full(ds)
@@ -438,14 +438,14 @@ def test_inc_process_many_one_to_many(dbconn) -> None:
         name="unpack",
         func=inc_func_unpack,
         input_dts=[ComputeInput(dt=tbl, join_type="full")],
-        output_dts=[tbl_rel],
+        output_dts=[ComputeOutput(dt=tbl_rel)],
     )
     step_pack = BatchTransformStep(
         ds=ds,
         name="pack",
         func=inc_func_pack,
         input_dts=[ComputeInput(dt=tbl_rel, join_type="full")],
-        output_dts=[tbl2],
+        output_dts=[ComputeOutput(dt=tbl2)],
     )
 
     step_unpack.run_full(ds)
@@ -506,14 +506,14 @@ def test_inc_process_many_one_to_many_change_primary(dbconn) -> None:
         name="unpack",
         func=inc_func_unpack,
         input_dts=[ComputeInput(dt=tbl, join_type="full")],
-        output_dts=[tbl_rel],
+        output_dts=[ComputeOutput(dt=tbl_rel)],
     )
     step_pack = BatchTransformStep(
         ds=ds,
         name="pack",
         func=inc_func_pack,
         input_dts=[ComputeInput(dt=tbl_rel, join_type="full")],
-        output_dts=[tbl2],
+        output_dts=[ComputeOutput(dt=tbl2)],
     )
 
     step_unpack.run_full(ds)
@@ -619,7 +619,7 @@ def test_error_handling(dbconn) -> None:
         name="bad",
         func=inc_func_bad,
         input_dts=[ComputeInput(dt=tbl, join_type="full")],
-        output_dts=[tbl_good],
+        output_dts=[ComputeOutput(dt=tbl_good)],
         chunk_size=1,
     )
     step_bad.run_full(ds)
@@ -631,7 +631,7 @@ def test_error_handling(dbconn) -> None:
         name="good",
         func=inc_func_good,
         input_dts=[ComputeInput(dt=tbl, join_type="full")],
-        output_dts=[tbl_good],
+        output_dts=[ComputeOutput(dt=tbl_good)],
         chunk_size=CHUNKSIZE,
     )
     step_good.run_full(ds)

--- a/tests/test_core_steps2.py
+++ b/tests/test_core_steps2.py
@@ -9,7 +9,7 @@ import pandas as pd
 from sqlalchemy import Column, String
 from sqlalchemy.sql.sqltypes import Integer
 
-from datapipe.compute import ComputeInput
+from datapipe.compute import ComputeInput, ComputeOutput
 from datapipe.datatable import DataStore
 from datapipe.run_config import RunConfig
 from datapipe.step.batch_generate import do_batch_generate
@@ -91,7 +91,7 @@ def test_batch_transform(dbconn):
         name="test",
         func=lambda df: df,
         input_dts=[ComputeInput(dt=tbl1, join_type="full")],
-        output_dts=[tbl2],
+        output_dts=[ComputeOutput(dt=tbl2)],
     )
 
     step.run_full(ds)
@@ -125,7 +125,7 @@ def test_batch_transform_with_filter(dbconn):
         name="test",
         func=lambda df: df,
         input_dts=[ComputeInput(dt=tbl1, join_type="full")],
-        output_dts=[tbl2],
+        output_dts=[ComputeOutput(dt=tbl2)],
     )
     step.run_full(
         ds,
@@ -151,7 +151,7 @@ def test_batch_transform_with_filter_not_in_transform_index(dbconn):
         name="test",
         func=lambda df: df[["item_id", "a"]],
         input_dts=[ComputeInput(dt=tbl1, join_type="full")],
-        output_dts=[tbl2],
+        output_dts=[ComputeOutput(dt=tbl2)],
     )
 
     step.run_full(
@@ -191,7 +191,7 @@ def test_batch_transform_with_dt_on_input_and_output(dbconn):
             ComputeInput(dt=tbl1, join_type="full"),
             ComputeInput(dt=tbl2, join_type="full"),
         ],
-        output_dts=[tbl2],
+        output_dts=[ComputeOutput(dt=tbl2)],
     )
 
     step.run_full(ds)
@@ -246,7 +246,7 @@ def test_batch_transform_with_fails(dbconn):
         name="step1",
         func=transform_func,
         input_dts=[ComputeInput(dt=tbl1, join_type="full")],
-        output_dts=[tbl2],
+        output_dts=[ComputeOutput(dt=tbl2)],
     )
 
     tbl1.store_chunk(
@@ -305,7 +305,7 @@ def test_transform_with_changelist(dbconn):
         name="test",
         func=func,
         input_dts=[ComputeInput(dt=tbl1, join_type="full")],
-        output_dts=[tbl2],
+        output_dts=[ComputeOutput(dt=tbl2)],
     )
 
     change_list = ChangeList()
@@ -354,7 +354,7 @@ def test_batch_transform_with_entity(dbconn):
             ComputeInput(dt=products, join_type="full"),
             ComputeInput(dt=items, join_type="full"),
         ],
-        output_dts=[items2],
+        output_dts=[ComputeOutput(dt=items2)],
     )
 
     step.run_full(ds)

--- a/tests/test_image_pipeline.py
+++ b/tests/test_image_pipeline.py
@@ -7,6 +7,7 @@ from PIL import Image
 from datapipe.compute import (
     Catalog,
     ComputeInput,
+    ComputeOutput,
     Pipeline,
     Table,
     build_compute,
@@ -66,7 +67,7 @@ def test_image_datatables(dbconn, tmp_dir):
         name="resize_images",
         func=resize_images,
         input_dts=[ComputeInput(dt=tbl1, join_type="full")],
-        output_dts=[tbl2],
+        output_dts=[ComputeOutput(dt=tbl2)],
     )
 
     step.run_full(ds)

--- a/tests/test_meta_transform_keys.py
+++ b/tests/test_meta_transform_keys.py
@@ -1,14 +1,15 @@
 import time
+from typing import cast
 
 import pandas as pd
-import pytest
 from sqlalchemy import Column, String
 
-from datapipe.compute import ComputeInput
+from datapipe.compute import Catalog, ComputeInput, ComputeOutput, Table
 from datapipe.datatable import DataStore
-from datapipe.step.batch_transform import BatchTransformStep
+from datapipe.step.batch_transform import BatchTransform, BatchTransformStep
 from datapipe.store.database import DBConn, TableStoreDB
 from datapipe.tests.util import assert_datatable_equal
+from datapipe.types import IndexDF, InputSpec, OutputSpec
 
 
 def test_transform_keys(dbconn: DBConn):
@@ -93,7 +94,7 @@ def test_transform_keys(dbconn: DBConn):
         func=transform_func,
         input_dts=[
             ComputeInput(
-                dt=posts,
+                dt=posts,  # [id, user_id, content]
                 join_type="inner",
                 keys={
                     "post_id": "id",
@@ -101,14 +102,25 @@ def test_transform_keys(dbconn: DBConn):
                 },
             ),
             ComputeInput(
-                dt=profiles,
+                dt=profiles,  # [id, username]
                 join_type="inner",
                 keys={
                     "user_id": "id",
                 },
             ),
         ],
-        output_dts=[output_dt],
+        # post, profiles -> output_dt
+        # 1 post [id, user_id, content] -> mapping [post_id, user_id, content]
+        # 2 profiles [id, username] -> mapping [user_id, username]
+        # output_dt 1x2 = [post_id, user_id, content, username] -> get output [post_id, username] -> mapping [id, user_name]
+        output_dts=[
+            ComputeOutput(
+                dt=output_dt,  # [id, user_id, content, username]
+                keys={
+                    "post_id": "id",
+                },
+            ),
+        ],
         transform_keys=["post_id", "user_id"],
     )
 
@@ -146,6 +158,20 @@ def test_transform_keys(dbconn: DBConn):
         ),
     )
 
+    # 11. Удаление lookup-записи должно удалить все output rows для связанных posts.
+    time.sleep(0.01)  # Небольшая задержка для различения timestamp'ов
+    profiles.delete_by_idx(cast(IndexDF, pd.DataFrame([{"id": "1"}])), now=time.time())
+    step.run_full(ds)
+
+    assert_datatable_equal(
+        output_dt,
+        pd.DataFrame(
+            [
+                {"id": "3", "user_id": "2", "content": "Post 3", "username": "bob"},
+            ]
+        ),
+    )
+
     # 9. Добавим новые данные и проверим инкрементальную обработку
     time.sleep(0.01)  # Небольшая задержка для различения timestamp'ов
     process_ts3 = time.time()
@@ -173,10 +199,1030 @@ def test_transform_keys(dbconn: DBConn):
         output_dt,
         pd.DataFrame(
             [
-                {"id": "1", "user_id": "1", "content": "Post 1", "username": "alice-updated"},
-                {"id": "2", "user_id": "1", "content": "Post 2", "username": "alice-updated"},
                 {"id": "3", "user_id": "2", "content": "Post 3", "username": "bob"},
-                {"id": "4", "user_id": "1", "content": "New Post 4", "username": "alice-updated"},
+            ]
+        ),
+    )
+
+
+def test_transform_output_spec_keys(dbconn: DBConn):
+    ds = DataStore(dbconn, create_meta_table=True)
+
+    catalog = Catalog(
+        {
+            "posts": Table(
+                store=TableStoreDB(
+                    dbconn,
+                    "posts",
+                    [
+                        Column("id", String, primary_key=True),
+                        Column("user_id", String, primary_key=True),
+                        Column("content", String),
+                    ],
+                    create_table=True,
+                )
+            ),
+            "profiles": Table(
+                store=TableStoreDB(
+                    dbconn,
+                    "profiles",
+                    [
+                        Column("id", String, primary_key=True),
+                        Column("username", String),
+                    ],
+                    create_table=True,
+                )
+            ),
+            "posts_with_username": Table(
+                store=TableStoreDB(
+                    dbconn,
+                    "posts_with_username",
+                    [
+                        Column("id", String, primary_key=True),
+                        Column("user_id", String),
+                        Column("content", String),
+                        Column("username", String),
+                    ],
+                    create_table=True,
+                )
+            ),
+        }
+    )
+
+    def transform_func(posts_df, profiles_df):
+        result = posts_df.merge(profiles_df, left_on="user_id", right_on="id", suffixes=("", "_profile"))
+        return result[["id", "user_id", "content", "username"]]
+
+    step = BatchTransform(
+        func=transform_func,
+        inputs=[
+            InputSpec(
+                table="posts",
+                keys={
+                    "post_id": "id",
+                    "user_id": "user_id",
+                },
+            ),
+            InputSpec(
+                table="profiles",
+                keys={
+                    "user_id": "id",
+                },
+            ),
+        ],
+        outputs=[OutputSpec(table="posts_with_username", keys={"post_id": "id"})],
+        transform_keys=["post_id", "user_id"],
+    ).build_compute(ds, catalog)[0]
+
+    assert isinstance(step, BatchTransformStep)
+    assert len(step.output_specs) == 1
+    assert step.output_specs[0].keys == {"post_id": "id"}
+
+
+def test_transform_keys_with_input_table_as_output(dbconn: DBConn):
+    ds = DataStore(dbconn, create_meta_table=True)
+
+    users = ds.create_table(
+        "users",
+        TableStoreDB(
+            dbconn,
+            "users",
+            [
+                Column("id", String, primary_key=True),
+                Column("name", String),
+            ],
+            create_table=True,
+        ),
+    )
+    scores = ds.create_table(
+        "scores",
+        TableStoreDB(
+            dbconn,
+            "scores",
+            [
+                Column("id", String, primary_key=True),
+                Column("score", String),
+                Column("user_name", String),
+            ],
+            create_table=True,
+        ),
+    )
+
+    process_ts = time.time()
+    users.store_chunk(
+        pd.DataFrame(
+            [
+                {"id": "u1", "name": "Alice"},
+                {"id": "u2", "name": "Bob"},
+            ]
+        ),
+        now=process_ts,
+    )
+    scores.store_chunk(
+        pd.DataFrame(
+            [
+                {"id": "u1", "score": "10", "user_name": ""},
+                {"id": "u2", "score": "20", "user_name": ""},
+            ]
+        ),
+        now=process_ts,
+    )
+
+    def transform_func(users_df, scores_df):
+        df = scores_df[["id", "score"]].merge(users_df, on="id")
+        return df.rename(columns={"name": "user_name"})[["id", "score", "user_name"]]
+
+    step = BatchTransformStep(
+        ds=ds,
+        name="test_input_table_as_output",
+        func=transform_func,
+        input_dts=[
+            ComputeInput(
+                dt=users,
+                join_type="full",
+                keys={
+                    "user_id": "id",
+                },
+            ),
+            ComputeInput(
+                dt=scores,
+                join_type="inner",
+                keys={
+                    "user_id": "id",
+                },
+            ),
+        ],
+        output_dts=[
+            ComputeOutput(
+                dt=scores,
+                keys={
+                    "user_id": "id",
+                },
+            )
+        ],
+        transform_keys=["user_id"],
+    )
+
+    step.run_full(ds)
+
+    assert_datatable_equal(
+        scores,
+        pd.DataFrame(
+            [
+                {"id": "u1", "score": "10", "user_name": "Alice"},
+                {"id": "u2", "score": "20", "user_name": "Bob"},
+            ]
+        ),
+    )
+
+    time.sleep(0.01)
+    users.store_chunk(pd.DataFrame([{"id": "u1", "name": "Alice Updated"}]), now=time.time())
+    step.run_full(ds)
+
+    assert_datatable_equal(
+        scores,
+        pd.DataFrame(
+            [
+                {"id": "u1", "score": "10", "user_name": "Alice Updated"},
+                {"id": "u2", "score": "20", "user_name": "Bob"},
+            ]
+        ),
+    )
+
+
+def test_batch_transform_outputs_with_different_key_mappings(dbconn: DBConn):
+    ds = DataStore(dbconn, create_meta_table=True)
+
+    catalog = Catalog(
+        {
+            "posts": Table(
+                store=TableStoreDB(
+                    dbconn,
+                    "posts",
+                    [
+                        Column("id", String, primary_key=True),
+                        Column("user_id", String, primary_key=True),
+                        Column("content", String),
+                    ],
+                    create_table=True,
+                )
+            ),
+            "profiles": Table(
+                store=TableStoreDB(
+                    dbconn,
+                    "profiles",
+                    [
+                        Column("id", String, primary_key=True),
+                        Column("username", String),
+                    ],
+                    create_table=True,
+                )
+            ),
+            "post_cards": Table(
+                store=TableStoreDB(
+                    dbconn,
+                    "post_cards",
+                    [
+                        Column("id", String, primary_key=True),
+                        Column("username", String),
+                        Column("content", String),
+                    ],
+                    create_table=True,
+                )
+            ),
+            "user_cards": Table(
+                store=TableStoreDB(
+                    dbconn,
+                    "user_cards",
+                    [
+                        Column("id", String, primary_key=True),
+                        Column("username", String),
+                        Column("posts_count", String),
+                    ],
+                    create_table=True,
+                )
+            ),
+        }
+    )
+
+    posts = catalog.get_datatable(ds, "posts")
+    profiles = catalog.get_datatable(ds, "profiles")
+    post_cards = catalog.get_datatable(ds, "post_cards")
+    user_cards = catalog.get_datatable(ds, "user_cards")
+
+    process_ts = time.time()
+    posts.store_chunk(
+        pd.DataFrame(
+            [
+                {"id": "p1", "user_id": "u1", "content": "Post 1"},
+                {"id": "p2", "user_id": "u1", "content": "Post 2"},
+                {"id": "p3", "user_id": "u2", "content": "Post 3"},
+            ]
+        ),
+        now=process_ts,
+    )
+    profiles.store_chunk(
+        pd.DataFrame(
+            [
+                {"id": "u1", "username": "alice"},
+                {"id": "u2", "username": "bob"},
+            ]
+        ),
+        now=process_ts,
+    )
+
+    def transform_func(posts_df, profiles_df):
+        df = posts_df.merge(profiles_df, left_on="user_id", right_on="id", suffixes=("_post", "_profile"))
+        post_cards_df = df.rename(columns={"id_post": "id"})[["id", "username", "content"]]
+        user_cards_df = (
+            df.groupby(["id_profile", "username"], as_index=False)
+            .agg(posts_count=("id_post", "count"))
+            .rename(columns={"id_profile": "id"})
+        )
+        user_cards_df["posts_count"] = user_cards_df["posts_count"].astype(str)
+        return post_cards_df, user_cards_df
+
+    step = BatchTransform(
+        func=transform_func,
+        inputs=[
+            InputSpec(
+                table="posts",
+                keys={
+                    "post_id": "id",
+                    "user_id": "user_id",
+                },
+            ),
+            InputSpec(
+                table="profiles",
+                keys={
+                    "user_id": "id",
+                },
+            ),
+        ],
+        outputs=[
+            OutputSpec(table="post_cards", keys={"post_id": "id"}),
+            OutputSpec(table="user_cards", keys={"user_id": "id"}),
+        ],
+        transform_keys=["post_id", "user_id"],
+    ).build_compute(ds, catalog)[0]
+
+    step.run_full(ds)
+
+    assert_datatable_equal(
+        post_cards,
+        pd.DataFrame(
+            [
+                {"id": "p1", "username": "alice", "content": "Post 1"},
+                {"id": "p2", "username": "alice", "content": "Post 2"},
+                {"id": "p3", "username": "bob", "content": "Post 3"},
+            ]
+        ),
+    )
+    assert_datatable_equal(
+        user_cards,
+        pd.DataFrame(
+            [
+                {"id": "u1", "username": "alice", "posts_count": "2"},
+                {"id": "u2", "username": "bob", "posts_count": "1"},
+            ]
+        ),
+    )
+
+    time.sleep(0.01)
+    profiles.delete_by_idx(cast(IndexDF, pd.DataFrame([{"id": "u1"}])), now=time.time())
+    step.run_full(ds)
+
+    assert_datatable_equal(
+        post_cards,
+        pd.DataFrame(
+            [
+                {"id": "p3", "username": "bob", "content": "Post 3"},
+            ]
+        ),
+    )
+    assert_datatable_equal(
+        user_cards,
+        pd.DataFrame(
+            [
+                {"id": "u2", "username": "bob", "posts_count": "1"},
+            ]
+        ),
+    )
+
+
+def test_transform_keys_with_composite_aliases_and_multiple_outputs(dbconn: DBConn):
+    ds = DataStore(dbconn, create_meta_table=True)
+
+    events = ds.create_table(
+        "events",
+        TableStoreDB(
+            dbconn,
+            "events",
+            [
+                Column("event_id", String, primary_key=True),
+                Column("tenant_id", String, primary_key=True),
+                Column("user_id", String),
+                Column("payload", String),
+            ],
+            create_table=True,
+        ),
+    )
+    tenants = ds.create_table(
+        "tenants",
+        TableStoreDB(
+            dbconn,
+            "tenants",
+            [
+                Column("id", String, primary_key=True),
+                Column("tenant_name", String),
+            ],
+            create_table=True,
+        ),
+    )
+    enriched_events = ds.create_table(
+        "enriched_events",
+        TableStoreDB(
+            dbconn,
+            "enriched_events",
+            [
+                Column("event_pk", String, primary_key=True),
+                Column("tenant_pk", String, primary_key=True),
+                Column("user_id", String),
+                Column("payload", String),
+                Column("tenant_name", String),
+            ],
+            create_table=True,
+        ),
+    )
+    event_summaries = ds.create_table(
+        "event_summaries",
+        TableStoreDB(
+            dbconn,
+            "event_summaries",
+            [
+                Column("summary_event_id", String, primary_key=True),
+                Column("summary_tenant_id", String, primary_key=True),
+                Column("summary", String),
+            ],
+            create_table=True,
+        ),
+    )
+
+    process_ts = time.time()
+    events.store_chunk(
+        pd.DataFrame(
+            [
+                {"event_id": "e1", "tenant_id": "t1", "user_id": "u1", "payload": "payload-1"},
+                {"event_id": "e2", "tenant_id": "t1", "user_id": "u2", "payload": "payload-2"},
+                {"event_id": "e3", "tenant_id": "t2", "user_id": "u3", "payload": "payload-3"},
+            ]
+        ),
+        now=process_ts,
+    )
+    tenants.store_chunk(
+        pd.DataFrame(
+            [
+                {"id": "t1", "tenant_name": "tenant-one"},
+                {"id": "t2", "tenant_name": "tenant-two"},
+            ]
+        ),
+        now=process_ts,
+    )
+
+    def transform_func(events_df, tenants_df):
+        df = events_df.merge(tenants_df, left_on="tenant_id", right_on="id")
+        enriched_df = df.rename(columns={"event_id": "event_pk", "tenant_id": "tenant_pk"})[
+            ["event_pk", "tenant_pk", "user_id", "payload", "tenant_name"]
+        ]
+        summary_df = df.rename(columns={"event_id": "summary_event_id", "tenant_id": "summary_tenant_id"})[
+            ["summary_event_id", "summary_tenant_id"]
+        ].copy()
+        summary_df["summary"] = [
+            f"{payload}@{tenant_name}" for payload, tenant_name in zip(df["payload"], df["tenant_name"])
+        ]
+        return enriched_df, summary_df
+
+    step = BatchTransformStep(
+        ds=ds,
+        name="test_composite_aliases",
+        func=transform_func,
+        input_dts=[
+            ComputeInput(
+                dt=events,
+                join_type="full",
+                keys={
+                    "task_event_id": "event_id",
+                    "task_tenant_id": "tenant_id",
+                },
+            ),
+            ComputeInput(
+                dt=tenants,
+                join_type="inner",
+                keys={
+                    "task_tenant_id": "id",
+                },
+            ),
+        ],
+        output_dts=[
+            ComputeOutput(
+                dt=enriched_events,
+                keys={
+                    "task_event_id": "event_pk",
+                    "task_tenant_id": "tenant_pk",
+                },
+            ),
+            ComputeOutput(
+                dt=event_summaries,
+                keys={
+                    "task_event_id": "summary_event_id",
+                    "task_tenant_id": "summary_tenant_id",
+                },
+            ),
+        ],
+        transform_keys=["task_event_id", "task_tenant_id"],
+    )
+
+    step.run_full(ds)
+
+    assert_datatable_equal(
+        enriched_events,
+        pd.DataFrame(
+            [
+                {
+                    "event_pk": "e1",
+                    "tenant_pk": "t1",
+                    "user_id": "u1",
+                    "payload": "payload-1",
+                    "tenant_name": "tenant-one",
+                },
+                {
+                    "event_pk": "e2",
+                    "tenant_pk": "t1",
+                    "user_id": "u2",
+                    "payload": "payload-2",
+                    "tenant_name": "tenant-one",
+                },
+                {
+                    "event_pk": "e3",
+                    "tenant_pk": "t2",
+                    "user_id": "u3",
+                    "payload": "payload-3",
+                    "tenant_name": "tenant-two",
+                },
+            ]
+        ),
+    )
+    assert_datatable_equal(
+        event_summaries,
+        pd.DataFrame(
+            [
+                {"summary_event_id": "e1", "summary_tenant_id": "t1", "summary": "payload-1@tenant-one"},
+                {"summary_event_id": "e2", "summary_tenant_id": "t1", "summary": "payload-2@tenant-one"},
+                {"summary_event_id": "e3", "summary_tenant_id": "t2", "summary": "payload-3@tenant-two"},
+            ]
+        ),
+    )
+
+    time.sleep(0.01)
+    tenants.store_chunk(pd.DataFrame([{"id": "t1", "tenant_name": "tenant-one-updated"}]), now=time.time())
+    step.run_full(ds)
+
+    assert_datatable_equal(
+        enriched_events,
+        pd.DataFrame(
+            [
+                {
+                    "event_pk": "e1",
+                    "tenant_pk": "t1",
+                    "user_id": "u1",
+                    "payload": "payload-1",
+                    "tenant_name": "tenant-one-updated",
+                },
+                {
+                    "event_pk": "e2",
+                    "tenant_pk": "t1",
+                    "user_id": "u2",
+                    "payload": "payload-2",
+                    "tenant_name": "tenant-one-updated",
+                },
+                {
+                    "event_pk": "e3",
+                    "tenant_pk": "t2",
+                    "user_id": "u3",
+                    "payload": "payload-3",
+                    "tenant_name": "tenant-two",
+                },
+            ]
+        ),
+    )
+    assert_datatable_equal(
+        event_summaries,
+        pd.DataFrame(
+            [
+                {"summary_event_id": "e1", "summary_tenant_id": "t1", "summary": "payload-1@tenant-one-updated"},
+                {"summary_event_id": "e2", "summary_tenant_id": "t1", "summary": "payload-2@tenant-one-updated"},
+                {"summary_event_id": "e3", "summary_tenant_id": "t2", "summary": "payload-3@tenant-two"},
+            ]
+        ),
+    )
+
+    time.sleep(0.01)
+    tenants.delete_by_idx(cast(IndexDF, pd.DataFrame([{"id": "t1"}])), now=time.time())
+    step.run_full(ds)
+
+    assert_datatable_equal(
+        enriched_events,
+        pd.DataFrame(
+            [
+                {
+                    "event_pk": "e3",
+                    "tenant_pk": "t2",
+                    "user_id": "u3",
+                    "payload": "payload-3",
+                    "tenant_name": "tenant-two",
+                },
+            ]
+        ),
+    )
+    assert_datatable_equal(
+        event_summaries,
+        pd.DataFrame(
+            [
+                {"summary_event_id": "e3", "summary_tenant_id": "t2", "summary": "payload-3@tenant-two"},
+            ]
+        ),
+    )
+
+
+def test_transform_keys_with_same_column_names_and_different_aliases(dbconn: DBConn):
+    ds = DataStore(dbconn, create_meta_table=True)
+
+    users = ds.create_table(
+        "users",
+        TableStoreDB(
+            dbconn,
+            "users",
+            [
+                Column("id", String, primary_key=True),
+                Column("name", String),
+                Column("team_id", String, primary_key=True),
+                Column("role_id", String, primary_key=True),
+            ],
+            create_table=True,
+        ),
+    )
+    teams = ds.create_table(
+        "teams",
+        TableStoreDB(
+            dbconn,
+            "teams",
+            [
+                Column("id", String, primary_key=True),
+                Column("name", String),
+            ],
+            create_table=True,
+        ),
+    )
+    roles = ds.create_table(
+        "roles",
+        TableStoreDB(
+            dbconn,
+            "roles",
+            [
+                Column("id", String, primary_key=True),
+                Column("name", String),
+            ],
+            create_table=True,
+        ),
+    )
+    memberships = ds.create_table(
+        "memberships",
+        TableStoreDB(
+            dbconn,
+            "memberships",
+            [
+                Column("member_id", String, primary_key=True),
+                Column("member_team_id", String, primary_key=True),
+                Column("member_role_id", String, primary_key=True),
+                Column("user_name", String),
+                Column("team_name", String),
+                Column("role_name", String),
+            ],
+            create_table=True,
+        ),
+    )
+
+    process_ts = time.time()
+    users.store_chunk(
+        pd.DataFrame(
+            [
+                {"id": "u1", "name": "Alice", "team_id": "t1", "role_id": "r1"},
+                {"id": "u2", "name": "Bob", "team_id": "t1", "role_id": "r2"},
+                {"id": "u3", "name": "Eve", "team_id": "t2", "role_id": "r1"},
+            ]
+        ),
+        now=process_ts,
+    )
+    teams.store_chunk(
+        pd.DataFrame(
+            [
+                {"id": "t1", "name": "Core"},
+                {"id": "t2", "name": "ML"},
+            ]
+        ),
+        now=process_ts,
+    )
+    roles.store_chunk(
+        pd.DataFrame(
+            [
+                {"id": "r1", "name": "Admin"},
+                {"id": "r2", "name": "Reviewer"},
+            ]
+        ),
+        now=process_ts,
+    )
+
+    def transform_func(users_df, teams_df, roles_df):
+        df = users_df.merge(teams_df, left_on="team_id", right_on="id", suffixes=("_user", "_team"))
+        df = df.merge(roles_df, left_on="role_id", right_on="id")
+        return pd.DataFrame(
+            {
+                "member_id": df["id_user"],
+                "member_team_id": df["team_id"],
+                "member_role_id": df["role_id"],
+                "user_name": df["name_user"],
+                "team_name": df["name_team"],
+                "role_name": df["name"],
+            }
+        )
+
+    step = BatchTransformStep(
+        ds=ds,
+        name="test_same_column_names_aliases",
+        func=transform_func,
+        input_dts=[
+            ComputeInput(
+                dt=users,
+                join_type="full",
+                keys={
+                    "user_id": "id",
+                    "team_id": "team_id",
+                    "role_id": "role_id",
+                },
+            ),
+            ComputeInput(
+                dt=teams,
+                join_type="inner",
+                keys={
+                    "team_id": "id",
+                },
+            ),
+            ComputeInput(
+                dt=roles,
+                join_type="inner",
+                keys={
+                    "role_id": "id",
+                },
+            ),
+        ],
+        output_dts=[
+            ComputeOutput(
+                dt=memberships,
+                keys={
+                    "user_id": "member_id",
+                    "team_id": "member_team_id",
+                    "role_id": "member_role_id",
+                },
+            ),
+        ],
+        transform_keys=["user_id", "team_id", "role_id"],
+    )
+
+    step.run_full(ds)
+
+    assert_datatable_equal(
+        memberships,
+        pd.DataFrame(
+            [
+                {
+                    "member_id": "u1",
+                    "member_team_id": "t1",
+                    "member_role_id": "r1",
+                    "user_name": "Alice",
+                    "team_name": "Core",
+                    "role_name": "Admin",
+                },
+                {
+                    "member_id": "u2",
+                    "member_team_id": "t1",
+                    "member_role_id": "r2",
+                    "user_name": "Bob",
+                    "team_name": "Core",
+                    "role_name": "Reviewer",
+                },
+                {
+                    "member_id": "u3",
+                    "member_team_id": "t2",
+                    "member_role_id": "r1",
+                    "user_name": "Eve",
+                    "team_name": "ML",
+                    "role_name": "Admin",
+                },
+            ]
+        ),
+    )
+
+    time.sleep(0.01)
+    teams.store_chunk(pd.DataFrame([{"id": "t1", "name": "Core Platform"}]), now=time.time())
+    step.run_full(ds)
+
+    assert_datatable_equal(
+        memberships,
+        pd.DataFrame(
+            [
+                {
+                    "member_id": "u1",
+                    "member_team_id": "t1",
+                    "member_role_id": "r1",
+                    "user_name": "Alice",
+                    "team_name": "Core Platform",
+                    "role_name": "Admin",
+                },
+                {
+                    "member_id": "u2",
+                    "member_team_id": "t1",
+                    "member_role_id": "r2",
+                    "user_name": "Bob",
+                    "team_name": "Core Platform",
+                    "role_name": "Reviewer",
+                },
+                {
+                    "member_id": "u3",
+                    "member_team_id": "t2",
+                    "member_role_id": "r1",
+                    "user_name": "Eve",
+                    "team_name": "ML",
+                    "role_name": "Admin",
+                },
+            ]
+        ),
+    )
+
+    time.sleep(0.01)
+    roles.delete_by_idx(cast(IndexDF, pd.DataFrame([{"id": "r1"}])), now=time.time())
+    step.run_full(ds)
+
+    assert_datatable_equal(
+        memberships,
+        pd.DataFrame(
+            [
+                {
+                    "member_id": "u2",
+                    "member_team_id": "t1",
+                    "member_role_id": "r2",
+                    "user_name": "Bob",
+                    "team_name": "Core Platform",
+                    "role_name": "Reviewer",
+                },
+            ]
+        ),
+    )
+
+
+def test_transform_keys_with_same_output_column_names_and_different_aliases(dbconn: DBConn):
+    ds = DataStore(dbconn, create_meta_table=True)
+
+    users = ds.create_table(
+        "users",
+        TableStoreDB(
+            dbconn,
+            "users",
+            [
+                Column("id", String, primary_key=True),
+                Column("name", String),
+                Column("role_id", String, primary_key=True),
+            ],
+            create_table=True,
+        ),
+    )
+    roles = ds.create_table(
+        "roles",
+        TableStoreDB(
+            dbconn,
+            "roles",
+            [
+                Column("id", String, primary_key=True),
+                Column("name", String),
+            ],
+            create_table=True,
+        ),
+    )
+    user_cards = ds.create_table(
+        "user_cards",
+        TableStoreDB(
+            dbconn,
+            "user_cards",
+            [
+                Column("id", String, primary_key=True),
+                Column("user_name", String),
+                Column("role_name", String),
+            ],
+            create_table=True,
+        ),
+    )
+    role_cards = ds.create_table(
+        "role_cards",
+        TableStoreDB(
+            dbconn,
+            "role_cards",
+            [
+                Column("id", String, primary_key=True),
+                Column("role_name", String),
+                Column("users_count", String),
+            ],
+            create_table=True,
+        ),
+    )
+
+    process_ts = time.time()
+    users.store_chunk(
+        pd.DataFrame(
+            [
+                {"id": "u1", "name": "Alice", "role_id": "r1"},
+                {"id": "u2", "name": "Bob", "role_id": "r2"},
+                {"id": "u3", "name": "Eve", "role_id": "r1"},
+            ]
+        ),
+        now=process_ts,
+    )
+    roles.store_chunk(
+        pd.DataFrame(
+            [
+                {"id": "r1", "name": "Admin"},
+                {"id": "r2", "name": "Reviewer"},
+            ]
+        ),
+        now=process_ts,
+    )
+
+    def transform_func(users_df, roles_df):
+        df = users_df.merge(roles_df, left_on="role_id", right_on="id", suffixes=("_user", "_role"))
+        user_cards_df = pd.DataFrame(
+            {
+                "id": df["id_user"],
+                "user_name": df["name_user"],
+                "role_name": df["name_role"],
+            }
+        )
+        role_cards_df = (
+            df.groupby(["id_role", "name_role"], as_index=False)
+            .agg(users_count=("id_user", "count"))
+            .rename(columns={"id_role": "id", "name_role": "role_name"})
+        )
+        role_cards_df["users_count"] = role_cards_df["users_count"].astype(str)
+        return user_cards_df, role_cards_df
+
+    step = BatchTransformStep(
+        ds=ds,
+        name="test_same_output_columns_aliases",
+        func=transform_func,
+        input_dts=[
+            ComputeInput(
+                dt=users,
+                join_type="full",
+                keys={
+                    "user_id": "id",
+                    "role_id": "role_id",
+                },
+            ),
+            ComputeInput(
+                dt=roles,
+                join_type="inner",
+                keys={
+                    "role_id": "id",
+                },
+            ),
+        ],
+        output_dts=[
+            ComputeOutput(
+                dt=user_cards,
+                keys={
+                    "user_id": "id",
+                },
+            ),
+            ComputeOutput(
+                dt=role_cards,
+                keys={
+                    "role_id": "id",
+                },
+            ),
+        ],
+        transform_keys=["user_id", "role_id"],
+    )
+
+    step.run_full(ds)
+
+    assert_datatable_equal(
+        user_cards,
+        pd.DataFrame(
+            [
+                {"id": "u1", "user_name": "Alice", "role_name": "Admin"},
+                {"id": "u2", "user_name": "Bob", "role_name": "Reviewer"},
+                {"id": "u3", "user_name": "Eve", "role_name": "Admin"},
+            ]
+        ),
+    )
+    assert_datatable_equal(
+        role_cards,
+        pd.DataFrame(
+            [
+                {"id": "r1", "role_name": "Admin", "users_count": "2"},
+                {"id": "r2", "role_name": "Reviewer", "users_count": "1"},
+            ]
+        ),
+    )
+
+    time.sleep(0.01)
+    roles.store_chunk(pd.DataFrame([{"id": "r1", "name": "Administrator"}]), now=time.time())
+    step.run_full(ds)
+
+    assert_datatable_equal(
+        user_cards,
+        pd.DataFrame(
+            [
+                {"id": "u1", "user_name": "Alice", "role_name": "Administrator"},
+                {"id": "u2", "user_name": "Bob", "role_name": "Reviewer"},
+                {"id": "u3", "user_name": "Eve", "role_name": "Administrator"},
+            ]
+        ),
+    )
+    assert_datatable_equal(
+        role_cards,
+        pd.DataFrame(
+            [
+                {"id": "r1", "role_name": "Administrator", "users_count": "2"},
+                {"id": "r2", "role_name": "Reviewer", "users_count": "1"},
+            ]
+        ),
+    )
+
+    time.sleep(0.01)
+    roles.delete_by_idx(cast(IndexDF, pd.DataFrame([{"id": "r1"}])), now=time.time())
+    step.run_full(ds)
+
+    assert_datatable_equal(
+        user_cards,
+        pd.DataFrame(
+            [
+                {"id": "u2", "user_name": "Bob", "role_name": "Reviewer"},
+            ]
+        ),
+    )
+    assert_datatable_equal(
+        role_cards,
+        pd.DataFrame(
+            [
+                {"id": "r2", "role_name": "Reviewer", "users_count": "1"},
             ]
         ),
     )

--- a/tests/test_table_store_filedir.py
+++ b/tests/test_table_store_filedir.py
@@ -1,6 +1,7 @@
 import base64
 import io
 import json
+from pathlib import Path
 
 import fsspec
 import numpy as np
@@ -186,13 +187,22 @@ def tmp_dir_with_json_data(tmp_dir):
     for fn, data in TEST_JSONS.items():
         with fsspec.open(f"{tmp_dir}/{fn}.json", "w+") as f:
             json.dump(data, f)
-    yield tmp_dir
+    yield canonical_local_path(tmp_dir)
 
 
 def get_test_df_filepath(test_df, tmp_dir_):
     test_df_filepath = test_df.copy()
     test_df_filepath["filepath"] = test_df_filepath["id"].map(lambda idx: f"{tmp_dir_}/{idx}.json")
     return test_df_filepath
+
+
+def canonical_local_path(path):
+    path = str(path)
+    if path.startswith("file://"):
+        return f"file://{Path(path.removeprefix('file://')).resolve()}"
+    if "://" in path:
+        return path
+    return str(Path(path).resolve())
 
 
 def test_read_json_rows(tmp_dir_with_json_data):
@@ -409,7 +419,7 @@ def tmp_several_dirs_with_json_data(tmp_dir):
                 out.write(f'{{"a": {i}, "b": {j}}}')
         with fsspec.open(f"{tmp_dir}/folder{i}/{i}.json", "w", auto_mkdir=True) as out:
             out.write(f'{{"a": {i}, "b": -1}}')
-    yield tmp_dir
+    yield canonical_local_path(tmp_dir)
 
 
 TEST_DF_FOLDER0 = pd.DataFrame(


### PR DESCRIPTION
## Summary

This PR extends transform key mapping to outputs and fixes cleanup behavior for aliased keys.

- Add `OutputSpec` / `ComputeOutput.keys` so transform keys can be explicitly mapped to output table primary keys.
- Make `BatchTransformStep` use explicit `ComputeInput` and `ComputeOutput` specs instead of accepting raw `DataTable` objects in compute-level APIs.
- Fix incomplete transform keys generated by SQL metadata aggregation and output cleanup when output PK names differ from transform key names.
- Add regression coverage for aliased input/output keys, composite aliases, duplicated physical `id` columns, multiple outputs, updates, and deletes.
- Fix macOS local path expectations in filedir tests and update `tqdm-loggable` to remove Python 3.12 deprecation warnings.