### PR TITLE
fix: advance offset for empty batch output to prevent infinite reprocessing in filter transforms

### DIFF
--- a/datapipe/step/batch_transform.py
+++ b/datapipe/step/batch_transform.py
@@ -597,38 +597,37 @@ class BaseBatchTransformStep(ComputeStep):
                 first_output = output_dfs
 
             # Извлекаем индекс из DataFrame результата
-            if not first_output.empty:
-                # Проверяем, что output содержит все transform_keys
-                # Если агрегация убрала некоторые колонки, используем input idx
-                missing_keys = set(self.transform_keys) - set(first_output.columns)
-                if missing_keys:
-                    # Агрегация убрала некоторые transform_keys из output
-                    # Используем input idx для расчета offset
-                    processed_idx = idx
-                else:
-                    processed_idx = data_to_index(first_output, self.transform_keys)
-
-                for inp in self.input_dts:
-                    # Найти максимальный update_ts из УСПЕШНО обработанного батча
-                    max_update_ts = self._get_max_update_ts_for_batch(ds, inp, processed_idx)
-
-                    if max_update_ts is not None:
-                        offset_key = (self.get_name(), inp.dt.name)
-                        # Добавляем offset в ChangeList для возврата из функции
-                        changes.offsets[offset_key] = max_update_ts
-                    else:
-                        # Диагностика: логируем почему offset не был вычислен
-                        logger.warning(
-                            f"Offset not calculated for {self.get_name()}, "
-                            f"input: {inp.dt.name}, processed_idx size: {len(processed_idx)}, "
-                            f"max_update_ts is None"
-                        )
+            # Важно: offset должен продвигаться даже если output пустой (фильтр отсеял все записи)
+            # Проверяем, что output содержит все transform_keys
+            missing_keys = set(self.transform_keys) - set(first_output.columns)
+            if missing_keys or first_output.empty:
+                # Агрегация убрала некоторые transform_keys из output
+                # ИЛИ output пустой (фильтр отсеял все записи)
+                # Используем input idx для расчета offset
+                processed_idx = idx
+                if first_output.empty:
+                    logger.debug(
+                        f"Output is empty for {self.get_name()}, using input idx for offset calculation "
+                        f"({len(idx)} rows processed)"
+                    )
             else:
-                # Диагностика: логируем пустой output
-                logger.warning(
-                    f"Offset not calculated for {self.get_name()}: "
-                    f"output is empty (0 rows processed)"
-                )
+                processed_idx = data_to_index(first_output, self.transform_keys)
+
+            for inp in self.input_dts:
+                # Найти максимальный update_ts из УСПЕШНО обработанного батча
+                max_update_ts = self._get_max_update_ts_for_batch(ds, inp, processed_idx)
+
+                if max_update_ts is not None:
+                    offset_key = (self.get_name(), inp.dt.name)
+                    # Добавляем offset в ChangeList для возврата из функции
+                    changes.offsets[offset_key] = max_update_ts
+                else:
+                    # Диагностика: логируем почему offset не был вычислен
+                    logger.warning(
+                        f"Offset not calculated for {self.get_name()}, "
+                        f"input: {inp.dt.name}, processed_idx size: {len(processed_idx)}, "
+                        f"max_update_ts is None"
+                    )
         else:
             # Диагностика: логируем отсутствие output_dfs
             logger.debug(

--- a/docs/tasks/empty_batch_edge_case.md
+++ b/docs/tasks/empty_batch_edge_case.md
@@ -1,0 +1,17 @@
+Прямое доказательство из логов
+По post_filter_to_adv_detection_moderate за весь 2.5-часовой прогон:
+
+Offset not calculated for post_filter_to_adv_detection_moderate_cb2cba6692: output is empty (0 rows processed)   ← на КАЖДОМ из 19 батчей
+Offsets not updated for post_filter_to_adv_detection_moderate_cb2cba6692: changes.offsets is empty after processing 19 batches
+То же самое для post_filter_to_moderate, filter_post_specifically_recommend, label_studio_output_to_recommendations, block_label_studio_output и др. Offset не записывается вообще.
+
+Механизм бага (точно по коду datapipe/step/batch_transform.py)
+После обработки батча новый offset для входа считается по ключам ВЫХОДА: processed_idx = data_to_index(first_output, transform_keys), затем max(update_ts) по мета-таблице входа, отфильтрованной этими ключами (_get_max_update_ts_for_batch, стр. 599–618).
+Если у батча выход пустой (first_output.empty) — offset для батча не считается (стр. 626–631), пишется warning.
+Offset коммитится в transform_input_offsets только если changes.offsets непустой (стр. 825–833).
+post_filter_to_moderate — это фильтр/роутер: из чанка post_input он оставляет только status=='on_moderation' + переписывает legacy-строки. Подавляющее большинство батчей changelist'а (обычные апдейты постов, не на модерации) → output пустой → offset не считается. Раз пустой на всех батчах → changes.offsets пустой → offset не двигается с Feb 17. Следующий прогон снова берёт Feb 17 → строит changelist на 3.5 млн строк → 5.5 ч. Самоподдерживающийся цикл.
+
+Суть дефекта: offset должен продвигаться по обработанному ВХОДУ (что прочитано/consumed), а не по ВЫХОДУ (что произведено). «Пустой выход» ≠ «ничего не обработано» — для фильтров это норма. Строки же реально помечаются обработанными (mark_rows_processed_success, стр. 587), но offset за ними не следует.
+
+Итоговая цепочка (всё подтверждено)
+use_offset_optimization=True на фильтр-трансформах → пустой output на батчах → offset не коммитится → застывает (Feb 17 / Mar 23) → каждый 5-минутный (!) запуск CronJob (*/5, Forbid) пересканирует месяцы изменений post_input (63 GB / 26 млн) → один прогон 8 ч → следующие ~100 расписаний пропускаются → так по кругу.

--- a/tests/offset_edge_cases/test_offset_commit_at_run_full_end.py
+++ b/tests/offset_edge_cases/test_offset_commit_at_run_full_end.py
@@ -404,13 +404,16 @@ def test_partial_processing_offset_not_updated(dbconn: DBConn):
 
 def test_empty_result_offset_not_updated(dbconn: DBConn):
     """
-    Тест: Пустой результат трансформации, offset НЕ обновляется.
+    Тест: Пустой результат трансформации, offset ОБНОВЛЯЕТСЯ.
+
+    Пустой output не означает что данные не обработаны - это нормально для фильтров.
+    Offset должен продвигаться по обработанному входу, а не по выходу.
 
     Сценарий:
     1. Создать данные
-    2. Трансформация возвращает пустой DataFrame
+    2. Трансформация возвращает пустой DataFrame (фильтр)
     3. Запустить run_full
-    4. Проверить что offset НЕ обновился
+    4. Проверить что offset обновился (данные обработаны, но отфильтрованы)
     """
     ds = DataStore(dbconn, create_meta_table=True)
 
@@ -438,7 +441,7 @@ def test_empty_result_offset_not_updated(dbconn: DBConn):
     )
     output_dt = ds.create_table("empty_output", output_store)
 
-    # Трансформация всегда возвращает пустой DataFrame
+    # Трансформация всегда возвращает пустой DataFrame (фильтр)
     def empty_func(df):
         return pd.DataFrame(columns=["id", "result"])
 
@@ -465,9 +468,11 @@ def test_empty_result_offset_not_updated(dbconn: DBConn):
     output_data = output_dt.get_data()
     assert len(output_data) == 0, "Output должен быть пустым"
 
-    # Проверяем что offset НЕ обновился
+    # Проверяем что offset ОБНОВИЛСЯ (несмотря на пустой результат)
     offsets = ds.offset_table.get_offsets_for_transformation(step.get_name())
-    assert len(offsets) == 0, "Offset не должен обновиться при пустом результате"
+    assert len(offsets) == 1, "Offset должен обновиться даже при пустом результате"
+    assert "empty_input" in offsets
+    assert offsets["empty_input"] >= now
 
 
 def test_run_changelist_does_not_update_offset(dbconn: DBConn):

--- a/tests/test_batch_transform_with_offset_optimization.py
+++ b/tests/test_batch_transform_with_offset_optimization.py
@@ -424,3 +424,208 @@ def test_batch_transform_offset_no_new_data(dbconn: DBConn):
     # Проверяем что результаты не изменились
     output_data = output_dt.get_data()
     assert len(output_data) == 2
+
+
+def test_batch_transform_max_records_per_run_keeps_boundary_timestamp_records(dbconn: DBConn):
+    """`max_records_per_run` не должен терять записи на границе одинакового update_ts."""
+    ds = DataStore(dbconn, create_meta_table=True)
+
+    input_store = TableStoreDB(
+        dbconn,
+        "test_input_max_records",
+        [Column("profile_id", String, primary_key=True), Column("value", Integer)],
+        create_table=True,
+    )
+    input_dt = ds.create_table("test_input_max_records", input_store)
+
+    output_store = TableStoreDB(
+        dbconn,
+        "test_output_max_records",
+        [Column("profile_id", String, primary_key=True), Column("result", Integer)],
+        create_table=True,
+    )
+    output_dt = ds.create_table("test_output_max_records", output_store)
+
+    def transform_func(df):
+        return df.rename(columns={"value": "result"})
+
+    step = BatchTransformStep(
+        ds=ds,
+        name="test_transform_max_records",
+        func=transform_func,
+        input_dts=[ComputeInput(dt=input_dt, join_type="full")],
+        output_dts=[output_dt],
+        transform_keys=["profile_id"],
+        chunk_size=2,
+        use_offset_optimization=True,
+        max_records_per_run=3,
+    )
+
+    first_ts = time.time() - 10
+    second_ts = first_ts + 1
+
+    input_dt.store_chunk(
+        pd.DataFrame(
+            {
+                "profile_id": ["p1", "p2", "p3", "p4"],
+                "value": [1, 2, 3, 4],
+            }
+        ),
+        now=first_ts,
+    )
+    input_dt.store_chunk(
+        pd.DataFrame(
+            {
+                "profile_id": ["p5", "p6"],
+                "value": [5, 6],
+            }
+        ),
+        now=second_ts,
+    )
+
+    step.run_full(ds)
+
+    first_run_output = output_dt.get_data().sort_values("profile_id").reset_index(drop=True)
+    assert first_run_output["profile_id"].tolist() == ["p1", "p2", "p3"]
+
+    offsets_after_first = ds.offset_table.get_offsets_for_transformation(step.get_name())
+    offset_after_first = offsets_after_first["test_input_max_records"]
+    assert first_ts <= offset_after_first < second_ts
+    assert step.get_changed_idx_count(ds) == 3
+
+    step.run_full(ds)
+
+    final_output = output_dt.get_data().sort_values("profile_id").reset_index(drop=True)
+    assert final_output["profile_id"].tolist() == ["p1", "p2", "p3", "p4", "p5", "p6"]
+
+    offsets_after_second = ds.offset_table.get_offsets_for_transformation(step.get_name())
+    offset_after_second = offsets_after_second["test_input_max_records"]
+    assert offset_after_second >= second_ts
+    assert step.get_changed_idx_count(ds) == 0
+
+
+def test_batch_transform_offset_with_empty_output_filter(dbconn: DBConn):
+    """
+    Тест для edge case: фильтр-трансформ возвращает пустой output.
+
+    Баг: offset не продвигается когда output пустой, что приводит к
+    бесконечной переобработке одних и тех же данных.
+
+    Ожидаемое поведение: offset должен продвигаться по обработанному ВХОДУ,
+    даже если выход пустой (все записи отфильтрованы).
+    """
+    ds = DataStore(dbconn, create_meta_table=True)
+
+    input_store = TableStoreDB(
+        dbconn,
+        "test_input_filter",
+        [
+            Column("id", String, primary_key=True),
+            Column("status", String),
+            Column("value", Integer),
+        ],
+        create_table=True,
+    )
+    input_dt = ds.create_table("test_input_filter", input_store)
+
+    output_store = TableStoreDB(
+        dbconn,
+        "test_output_filter",
+        [
+            Column("id", String, primary_key=True),
+            Column("status", String),
+            Column("value", Integer),
+        ],
+        create_table=True,
+    )
+    output_dt = ds.create_table("test_output_filter", output_store)
+
+    # Счетчик вызовов для отслеживания переобработки
+    call_data = {"calls": 0, "processed_ids": []}
+
+    def filter_func(df):
+        """Фильтр: оставляем только записи со status='approved'"""
+        call_data["calls"] += 1
+        call_data["processed_ids"].extend(df["id"].tolist())
+        # Фильтруем - может вернуть пустой DataFrame
+        return df[df["status"] == "approved"]
+
+    step = BatchTransformStep(
+        ds=ds,
+        name="test_filter_transform",
+        func=filter_func,
+        input_dts=[ComputeInput(dt=input_dt, join_type="full")],
+        output_dts=[output_dt],
+        transform_keys=["id"],
+        use_offset_optimization=True,
+    )
+
+    # Первая партия: все записи с status='pending' (НЕ пройдут фильтр)
+    first_ts = time.time()
+    input_dt.store_chunk(
+        pd.DataFrame({
+            "id": ["1", "2", "3"],
+            "status": ["pending", "pending", "pending"],
+            "value": [10, 20, 30],
+        }),
+        now=first_ts,
+    )
+
+    # Первый запуск - обработка записей с пустым output
+    step.run_full(ds)
+
+    # Проверяем что функция вызвалась и обработала записи
+    assert call_data["calls"] == 1
+    assert sorted(call_data["processed_ids"]) == ["1", "2", "3"]
+
+    # Проверяем что output пустой (все отфильтровались)
+    output_data = output_dt.get_data()
+    assert len(output_data) == 0
+
+    # КРИТИЧЕСКАЯ ПРОВЕРКА: offset должен продвинуться несмотря на пустой output!
+    offsets = ds.offset_table.get_offsets_for_transformation(step.get_name())
+    assert "test_input_filter" in offsets, "Offset должен быть записан даже при пустом output"
+    first_offset = offsets["test_input_filter"]
+    assert first_offset >= first_ts, f"Offset {first_offset} должен быть >= {first_ts}"
+
+    # Проверяем что changelist теперь пустой (нет новых данных)
+    changed_count = step.get_changed_idx_count(ds)
+    assert changed_count == 0, f"Должно быть 0 новых записей, но найдено {changed_count}"
+
+    # Вторая партия: добавляем новые данные (также pending)
+    time.sleep(0.01)
+    second_ts = time.time()
+    input_dt.store_chunk(
+        pd.DataFrame({
+            "id": ["4", "5"],
+            "status": ["approved", "pending"],  # Только '4' пройдет фильтр
+            "value": [40, 50],
+        }),
+        now=second_ts,
+    )
+
+    # Сбрасываем счетчик
+    call_data["calls"] = 0
+    call_data["processed_ids"] = []
+
+    # Второй запуск - должны обработаться ТОЛЬКО новые записи (4, 5)
+    step.run_full(ds)
+
+    # КРИТИЧЕСКАЯ ПРОВЕРКА: старые записи (1, 2, 3) НЕ должны переобрабатываться!
+    assert call_data["calls"] == 1
+    assert sorted(call_data["processed_ids"]) == ["4", "5"], (
+        f"Должны обработаться только новые записи ['4', '5'], "
+        f"но обработались {sorted(call_data['processed_ids'])}"
+    )
+
+    # Проверяем output - должна быть только одна запись (id='4')
+    output_data = output_dt.get_data()
+    assert len(output_data) == 1
+    assert output_data["id"].tolist() == ["4"]
+    assert output_data["status"].tolist() == ["approved"]
+
+    # Проверяем что offset снова продвинулся
+    offsets = ds.offset_table.get_offsets_for_transformation(step.get_name())
+    second_offset = offsets["test_input_filter"]
+    assert second_offset >= second_ts
+    assert second_offset > first_offset, "Offset должен продвинуться после второй партии"

--- a/tests/test_offset_auto_update.py
+++ b/tests/test_offset_auto_update.py
@@ -358,7 +358,10 @@ def test_works_without_offset_table(dbconn: DBConn):
 
 def test_offset_not_updated_on_empty_result(dbconn: DBConn):
     """
-    Тест что offset НЕ обновляется если трансформация вернула пустой результат
+    Тест что offset ОБНОВЛЯЕТСЯ даже если трансформация вернула пустой результат.
+
+    Пустой output не означает что данные не обработаны - это нормально для фильтров.
+    Offset должен продвигаться по обработанному входу, а не по выходу.
     """
     ds = DataStore(dbconn, create_meta_table=True)
 
@@ -378,7 +381,7 @@ def test_offset_not_updated_on_empty_result(dbconn: DBConn):
     )
     output_dt = ds.create_table("empty_result_output", output_store)
 
-    # Трансформация которая всегда возвращает пустой DataFrame
+    # Трансформация которая всегда возвращает пустой DataFrame (фильтр)
     def transform_func(df):
         return pd.DataFrame(columns=["id", "result"])
 
@@ -403,6 +406,8 @@ def test_offset_not_updated_on_empty_result(dbconn: DBConn):
     output_data = output_dt.get_data()
     assert len(output_data) == 0
 
-    # Проверяем что offset НЕ обновился (потому что результат пустой)
+    # Проверяем что offset ОБНОВИЛСЯ (несмотря на пустой результат)
     offsets = ds.offset_table.get_offsets_for_transformation(step.get_name())
-    assert len(offsets) == 0, "Offset не должен обновиться при пустом результате"
+    assert len(offsets) == 1, "Offset должен обновиться даже при пустом результате"
+    assert "empty_result_input" in offsets
+    assert offsets["empty_result_input"] >= now


### PR DESCRIPTION
Изменения:

- batch_transform.py - фикс логики offset calculation
- test_batch_transform_with_offset_optimization.py - новый тест - тест для max_records_per_run
- docs/tasks/empty_batch_edge_case.md - документация бага