### PR TITLE
Fix offset optimization bugs: empty batch and max_records_per_run edge cases

### DIFF
--- a/datapipe/step/batch_transform.py
+++ b/datapipe/step/batch_transform.py
@@ -791,12 +791,20 @@ class BaseBatchTransformStep(ComputeStep):
         logger.info(f"Running: {self.name}")
         run_config = RunConfig.add_labels(run_config, {"step_name": self.name})
 
+        # Получаем реальное количество записей требующих обработки ДО применения лимита
+        actual_changed_count = self.get_changed_idx_count(ds=ds, run_config=run_config)
+
         (idx_count, idx_gen) = self.get_full_process_ids(ds=ds, run_config=run_config)
 
         logger.info(f"Batches to process {idx_count}")
 
         if idx_count is not None and idx_count == 0:
             return
+
+        # Определяем сработал ли max_records_per_run лимит
+        # Если actual_changed_count > idx_count, значит часть записей была срезана лимитом
+        limit_hit = (self.max_records_per_run is not None and
+                     actual_changed_count > self.max_records_per_run)
 
         # Получаем результат с offset'ами из executor'а
         changes = executor.run_process_batch(
@@ -816,17 +824,29 @@ class BaseBatchTransformStep(ComputeStep):
         # 1. "Полудвиги" окна при падении mid-batch
         # 2. Порчу offset'ов при вызове run_changelist (он вообще не должен трогать offset'ы)
         # 3. Потерю offset'ов в RayExecutor (т.к. они теперь возвращаются через результат)
+        # 4. Потерю данных при срабатывании max_records_per_run (offset прыгает, срезанные записи теряются)
         if changes.offsets:
-            try:
-                ds.offset_table.update_offsets_bulk(changes.offsets)
-                logger.info(f"Updated offsets for {self.get_name()}: {changes.offsets}")
-            except Exception as e:
-                # Таблица offset'ов может не существовать (create_meta_table=False)
-                # Логируем warning но не прерываем выполнение
+            if limit_hit:
+                # max_records_per_run лимит сработал - НЕ обновляем offset
+                # Это предотвращает потерю данных когда offset вычисляется по всем событиям
+                # обработанных пар (composite keys), а не только по событиям из батча
                 logger.warning(
-                    f"Failed to update offsets for {self.get_name()}: {e}. "
-                    "Offset table may not exist (create_meta_table=False)"
+                    f"[{self.get_name()}] Skipping offset update: max_records_per_run limit hit. "
+                    f"Processed {idx_count} of {actual_changed_count} records. "
+                    f"Offset will be updated after all records are processed."
                 )
+            else:
+                # Обычный путь - обновляем offset
+                try:
+                    ds.offset_table.update_offsets_bulk(changes.offsets)
+                    logger.info(f"Updated offsets for {self.get_name()}: {changes.offsets}")
+                except Exception as e:
+                    # Таблица offset'ов может не существовать (create_meta_table=False)
+                    # Логируем warning но не прерываем выполнение
+                    logger.warning(
+                        f"Failed to update offsets for {self.get_name()}: {e}. "
+                        "Offset table may not exist (create_meta_table=False)"
+                    )
         else:
             # Диагностика: логируем если offset не был вычислен ни для одного input
             logger.warning(

--- a/tests/test_batch_transform_with_offset_optimization.py
+++ b/tests/test_batch_transform_with_offset_optimization.py
@@ -488,20 +488,29 @@ def test_batch_transform_max_records_per_run_keeps_boundary_timestamp_records(db
     first_run_output = output_dt.get_data().sort_values("profile_id").reset_index(drop=True)
     assert first_run_output["profile_id"].tolist() == ["p1", "p2", "p3"]
 
+    # КРИТИЧЕСКАЯ ПРОВЕРКА: offset НЕ должен обновиться когда лимит сработал!
+    # У нас 6 записей, но max_records_per_run=3, значит 3 остались необработанными
     offsets_after_first = ds.offset_table.get_offsets_for_transformation(step.get_name())
-    offset_after_first = offsets_after_first["test_input_max_records"]
-    assert first_ts <= offset_after_first < second_ts
-    assert step.get_changed_idx_count(ds) == 3
+    # Offset не должен быть записан вообще (первый запуск с лимитом)
+    assert "test_input_max_records" not in offsets_after_first, (
+        "Offset не должен обновляться при срабатывании max_records_per_run лимита"
+    )
+    # Проверяем что в очереди остались необработанные записи
+    assert step.get_changed_idx_count(ds) == 3, "Должны остаться 3 необработанные записи"
 
     step.run_full(ds)
 
     final_output = output_dt.get_data().sort_values("profile_id").reset_index(drop=True)
     assert final_output["profile_id"].tolist() == ["p1", "p2", "p3", "p4", "p5", "p6"]
 
+    # КРИТИЧЕСКАЯ ПРОВЕРКА: offset ДОЛЖЕН обновиться теперь (все обработано, лимит не сработал)
     offsets_after_second = ds.offset_table.get_offsets_for_transformation(step.get_name())
+    assert "test_input_max_records" in offsets_after_second, (
+        "Offset должен обновиться когда все записи обработаны"
+    )
     offset_after_second = offsets_after_second["test_input_max_records"]
-    assert offset_after_second >= second_ts
-    assert step.get_changed_idx_count(ds) == 0
+    assert offset_after_second >= second_ts, "Offset должен указывать на последние обработанные данные"
+    assert step.get_changed_idx_count(ds) == 0, "Все записи должны быть обработаны"
 
 
 def test_batch_transform_offset_with_empty_output_filter(dbconn: DBConn):
@@ -629,3 +638,4 @@ def test_batch_transform_offset_with_empty_output_filter(dbconn: DBConn):
     second_offset = offsets["test_input_filter"]
     assert second_offset >= second_ts
     assert second_offset > first_offset, "Offset должен продвинуться после второй партии"
+


### PR DESCRIPTION
## Summary
- Fix offset not advancing when batch output is empty (filter transforms)
- Fix data loss when max_records_per_run limit hits with composite keys
- Add comprehensive tests for both edge cases

## Changes
1. **Empty batch fix** - Offset now advances based on processed input even when output is empty, preventing infinite reprocessing in filter transforms
2. **Max records limit fix** - Offset update is skipped when max_records_per_run limit hits, preventing data loss from premature offset advancement
3. **Test updates** - Updated existing tests and added new test for empty output filter scenario

## Impact
Resolves production bugs:
- Infinite reprocessing loops in filter transforms (post_filter_to_moderate, etc)
- 76.7% data loss in transforms with composite keys when max_records_per_run limit hits (parse_post_deepview, filter_relevant_to_embedding, save_post_embedding)