### PR TITLE
Core/chunk inserts

### DIFF
--- a/libs/datapipe-core/CHANGELOG.md
+++ b/libs/datapipe-core/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Added `fail_fast` flag to `RunConfig` (defaults from new `DATAPIPE_FAIL_FAST`
   setting); when set, `BatchTransformStep` re-raises processing errors instead
   of recording them as batch errors and continuing
+* Chunked bulk `INSERT ... VALUES` statements in `TableStoreDB.update_rows`
+  and `SQLTableMeta`'s insert/update paths so they stay under Postgres's
+  65535 bind-parameter limit; needed once the driver binds parameters
+  server-side (see following change)
 
 # 0.15.0
 

--- a/libs/datapipe-core/datapipe/meta/sql_meta.py
+++ b/libs/datapipe-core/datapipe/meta/sql_meta.py
@@ -19,7 +19,7 @@ from opentelemetry import trace
 from datapipe.compute import ComputeInput, ComputeOutput
 from datapipe.meta.base import MetaPlane, TableDebugInfo, TableMeta, TransformMeta
 from datapipe.run_config import LabelDict, RunConfig
-from datapipe.sql_util import sql_apply_idx_filter_to_table, sql_apply_runconfig_filter
+from datapipe.sql_util import chunk_records_for_insert, sql_apply_idx_filter_to_table, sql_apply_runconfig_filter
 from datapipe.store.database import DBConn, MetaKey
 from datapipe.store.table_store import TableStore
 from datapipe.types import (
@@ -296,20 +296,21 @@ class SQLTableMeta(TableMeta):
         if df.empty:
             return
 
-        insert_sql = self.dbconn.insert(self.sql_table).values(df.to_dict(orient="records"))
-
-        sql = insert_sql.on_conflict_do_update(
-            index_elements=self.primary_keys,
-            set_={
-                "hash": insert_sql.excluded.hash,
-                "update_ts": insert_sql.excluded.update_ts,
-                "process_ts": insert_sql.excluded.process_ts,
-                "delete_ts": insert_sql.excluded.delete_ts,
-            },
-        )
-
         with self.dbconn.con.begin() as con:
-            con.execute(sql)
+            for chunk in chunk_records_for_insert(df.to_dict(orient="records")):
+                insert_sql = self.dbconn.insert(self.sql_table).values(chunk)
+
+                sql = insert_sql.on_conflict_do_update(
+                    index_elements=self.primary_keys,
+                    set_={
+                        "hash": insert_sql.excluded.hash,
+                        "update_ts": insert_sql.excluded.update_ts,
+                        "process_ts": insert_sql.excluded.process_ts,
+                        "delete_ts": insert_sql.excluded.delete_ts,
+                    },
+                )
+
+                con.execute(sql)
 
     def mark_rows_deleted(
         self,
@@ -565,23 +566,22 @@ class SQLTransformMeta(TransformMeta):
     ) -> None:
         idx = cast(IndexDF, idx[self.transform_keys])
 
-        insert_sql = self.dbconn.insert(self.sql_table).values(
-            [
-                {
-                    "process_ts": 0,
-                    "is_success": False,
-                    "priority": 0,
-                    "error": None,
-                    **idx_dict,  # type: ignore
-                }
-                for idx_dict in idx.to_dict(orient="records")
-            ]
-        )
-
-        sql = insert_sql.on_conflict_do_nothing(index_elements=self.transform_keys)
+        records = [
+            {
+                "process_ts": 0,
+                "is_success": False,
+                "priority": 0,
+                "error": None,
+                **idx_dict,  # type: ignore
+            }
+            for idx_dict in idx.to_dict(orient="records")
+        ]
 
         with self.dbconn.con.begin() as con:
-            con.execute(sql)
+            for chunk in chunk_records_for_insert(records):
+                insert_sql = self.dbconn.insert(self.sql_table).values(chunk)
+                sql = insert_sql.on_conflict_do_nothing(index_elements=self.transform_keys)
+                con.execute(sql)
 
     def mark_rows_processed_success(
         self,
@@ -619,31 +619,31 @@ class SQLTransformMeta(TransformMeta):
                 con.execute(insert_sql)
 
         else:
-            insert_sql = self.dbconn.insert(self.sql_table).values(
-                [
-                    {
-                        "process_ts": process_ts,
-                        "is_success": True,
-                        "priority": 0,
-                        "error": None,
-                        **idx_dict,  # type: ignore
-                    }
-                    for idx_dict in idx.to_dict(orient="records")
-                ]
-            )
-
-            sql = insert_sql.on_conflict_do_update(
-                index_elements=self.transform_keys,
-                set_={
+            records = [
+                {
                     "process_ts": process_ts,
                     "is_success": True,
+                    "priority": 0,
                     "error": None,
-                },
-            )
+                    **idx_dict,  # type: ignore
+                }
+                for idx_dict in idx.to_dict(orient="records")
+            ]
 
-            # execute
             with self.dbconn.con.begin() as con:
-                con.execute(sql)
+                for chunk in chunk_records_for_insert(records):
+                    insert_sql = self.dbconn.insert(self.sql_table).values(chunk)
+
+                    sql = insert_sql.on_conflict_do_update(
+                        index_elements=self.transform_keys,
+                        set_={
+                            "process_ts": process_ts,
+                            "is_success": True,
+                            "error": None,
+                        },
+                    )
+
+                    con.execute(sql)
 
     def mark_rows_processed_error(
         self,
@@ -658,31 +658,31 @@ class SQLTransformMeta(TransformMeta):
         if len(idx) == 0:
             return
 
-        insert_sql = self.dbconn.insert(self.sql_table).values(
-            [
-                {
-                    "process_ts": process_ts,
-                    "is_success": False,
-                    "priority": 0,
-                    "error": error,
-                    **idx_dict,  # type: ignore
-                }
-                for idx_dict in idx.to_dict(orient="records")
-            ]
-        )
-
-        sql = insert_sql.on_conflict_do_update(
-            index_elements=self.transform_keys,
-            set_={
+        records = [
+            {
                 "process_ts": process_ts,
                 "is_success": False,
+                "priority": 0,
                 "error": error,
-            },
-        )
+                **idx_dict,  # type: ignore
+            }
+            for idx_dict in idx.to_dict(orient="records")
+        ]
 
-        # execute
         with self.dbconn.con.begin() as con:
-            con.execute(sql)
+            for chunk in chunk_records_for_insert(records):
+                insert_sql = self.dbconn.insert(self.sql_table).values(chunk)
+
+                sql = insert_sql.on_conflict_do_update(
+                    index_elements=self.transform_keys,
+                    set_={
+                        "process_ts": process_ts,
+                        "is_success": False,
+                        "error": error,
+                    },
+                )
+
+                con.execute(sql)
 
     def get_metadata_size(self) -> int:
         sql = sa.select(sa.func.count()).select_from(self.sql_table)

--- a/libs/datapipe-core/datapipe/sql_util.py
+++ b/libs/datapipe-core/datapipe/sql_util.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any
+from typing import Any, Hashable, Iterator
 
 from sqlalchemy import (
     BigInteger,
@@ -58,6 +58,26 @@ def sql_apply_runconfig_filter(
                 sql = sql.where(table.c[k] == v)
 
     return sql
+
+
+# Postgres caps a single query at 65535 bind parameters. psycopg2 masked this
+# limit by interpolating parameters into the query text client-side; psycopg3
+# binds them server-side by default, so large multi-row INSERT ... VALUES
+# statements now need to be chunked to stay under the limit.
+POSTGRES_MAX_BIND_PARAMS = 65535
+
+
+def chunk_records_for_insert(
+    records: list[dict[Hashable, Any]],
+    max_params: int = POSTGRES_MAX_BIND_PARAMS,
+) -> Iterator[list[dict[Hashable, Any]]]:
+    if not records:
+        return
+
+    chunk_size = max(1, max_params // len(records[0]))
+
+    for i in range(0, len(records), chunk_size):
+        yield records[i : i + chunk_size]
 
 
 SCHEMA_TO_DTYPE_LOOKUP = {

--- a/libs/datapipe-core/datapipe/store/database.py
+++ b/libs/datapipe-core/datapipe/store/database.py
@@ -12,7 +12,7 @@ from sqlalchemy.sql.base import SchemaEventTarget
 from sqlalchemy.sql.expression import delete, select
 
 from datapipe.run_config import RunConfig
-from datapipe.sql_util import sql_apply_idx_filter_to_table, sql_apply_runconfig_filter
+from datapipe.sql_util import chunk_records_for_insert, sql_apply_idx_filter_to_table, sql_apply_runconfig_filter
 from datapipe.store.table_store import TableStore, TableStoreCaps
 from datapipe.types import DataDF, DataSchema, IndexDF, MetaSchema, OrmTable, TAnyDF
 
@@ -243,18 +243,24 @@ class TableStoreDB(TableStore):
         df_records = df.astype(object)
         df_records[pd.isna(df_records)] = None
         records = df_records.to_dict(orient="records")
-        insert_sql = self.dbconn.insert(self.data_table).values(records)
-
-        if len(self.data_keys) > 0:
-            sql = insert_sql.on_conflict_do_update(
-                index_elements=self.primary_keys,
-                set_={col.name: insert_sql.excluded[col.name] for col in self.data_sql_schema if not col.primary_key},
-            )
-        else:
-            sql = insert_sql.on_conflict_do_nothing(index_elements=self.primary_keys)
 
         with self.dbconn.con.begin() as con:
-            con.execute(sql)
+            for chunk in chunk_records_for_insert(records):
+                insert_sql = self.dbconn.insert(self.data_table).values(chunk)
+
+                if len(self.data_keys) > 0:
+                    sql = insert_sql.on_conflict_do_update(
+                        index_elements=self.primary_keys,
+                        set_={
+                            col.name: insert_sql.excluded[col.name]
+                            for col in self.data_sql_schema
+                            if not col.primary_key
+                        },
+                    )
+                else:
+                    sql = insert_sql.on_conflict_do_nothing(index_elements=self.primary_keys)
+
+                con.execute(sql)
 
     # Fix numpy types in IndexDF
     def _get_sql_param(self, param):


### PR DESCRIPTION
Chunk bulk INSERT ... VALUES statements to respect Postgres's 65535 bind-parameter limit

psycopg2 interpolated bound parameters client-side before sending queries, so large multi-row INSERT ... VALUES statements never hit Postgres's wire-protocol limit of 65535 bind parameters per query. psycopg3 binds parameters server-side by default, so the same unchunked bulk upserts now fail with "number of parameters must be between 0 and 65535" once row_count * column_count exceeds that limit.

Add chunk_records_for_insert() in sql_util.py and use it at every unchunked bulk-insert call site: TableStoreDB.update_rows (the main data-write path) and SQLTableMeta's update_rows, insert_rows, mark_rows_processed_success, and mark_rows_processed_error.