### PR TITLE
detection_tags: stable metrics across seeds/machines (config-only) + FiftyOne GT fix

### DIFF
--- a/.claude/skills/setup-detection-tags/SKILL.md
+++ b/.claude/skills/setup-detection-tags/SKILL.md
@@ -64,33 +64,51 @@ A is measured once on the full frozen val and its numbers are stable, and B is c
 same val. `add_request.py --subset train|val` pins a batch; the load step emits `image__subset_hint`
 and the split step honors it (random split only fills images without a hint).
 
-Batches (COCO cat/dog; the pre-staged cache holds **500 images**, so keep the total ≤ 500 or expand
-the cache — see Troubleshooting):
+Batches (COCO cat/dog; the pre-staged cache holds **1000 images** — fetch it from the public bucket
+or build it, see Troubleshooting; keep the batch total ≤ the cache size):
 
 | batch | n | offset | subset | tag | darken | when |
 |-------|---|--------|--------|-----|--------|------|
-| `base-train`   | 200 | 0   | train | —     | —    | part 1 |
-| `base-val`     | 75  | 200 | val   | —     | —    | part 1 |
-| `night-val`    | 75  | 275 | val   | night | 0.40 | part 1 |
-| `night-train-a`| 50  | 350 | train | night | 0.30 | part 2 |
-| `night-train-b`| 50  | 400 | train | night | 0.40 | part 2 |
-| `night-train-c`| 50  | 450 | train | night | 0.55 | part 2 |
+| `base-train`   | 400 | 0   | train | —     | —    | part 1 |
+| `base-val`     | 150 | 400 | val   | —     | —    | part 1 |
+| `night-val`    | 150 | 550 | val   | night | 0.40 | part 1 |
+| `night-train-a`| 100 | 700 | train | night | 0.30 | part 2 |
+| `night-train-b`| 100 | 800 | train | night | 0.40 | part 2 |
+| `night-train-c`| 100 | 900 | train | night | 0.55 | part 2 |
 
 **Why THREE night-train batches with different gammas (0.30/0.40/0.55 around val's 0.40):** a single
-gamma makes model B memorize that exact darkness (night/train ~0.95, night/val flat); gamma DIVERSITY
+gamma makes model B memorize that exact darkness (night/train high, night/val flat); gamma DIVERSITY
 forces it to generalize "low light", which is what lifts the held-out val. More epochs does NOT fix
-this (30 epochs = deeper memorization, val drops) — the lever is data diversity, keep epochs=10.
+this (deeper memorization, val drops) — the lever is data diversity, keep epochs=5.
 
-**Cross-machine numbers:** training is bit-reproducible on one machine, but weights (and hence
-metrics) legitimately differ across GPU/CPU models — that is float arithmetic on different chips, not
-a bug (verified down to byte-identical augmented batches). Quote reference numbers per hardware.
+**Why 1000 images / batch=32 / epochs=5 / freeze=10 / prediction_threshold=0.10** (validated by a
+130+-run sweep + multi-seed full-pipe cycles; the headline metric is **weighted F1 on val**):
+- `batch=10` gave noisy gradients — the B−A margin flipped sign depending on seed/machine; `batch=32`
+  keeps it positive on every seed tested.
+- Doubling data (500→1000) doubled val support (379/207 boxes) and stabilized absolutes; with
+  `epochs=5` the fitness curve still rises at the last epoch, so best.pt == last.pt (no
+  epoch-selection jitter).
+- `freeze=10` (frozen backbone, only the head trains) is the biggest stability lever: far fewer
+  degrees of freedom → per-seed/per-machine F1 spread collapses from 12-15pp to 2-5pp.
+- `prediction_threshold=0.10` on the Inference step pins ONE operating point for all models and
+  machines. Without it each model gets its own `best_threshold` from a noisy F1 curve (observed
+  0.06-0.15), which both jitters the reported metrics AND flatters the weak baseline (best_threshold
+  maximizes F1 by construction), shrinking the B−A gap to noise on unlucky seeds.
 
-**Deterministic reference** (gpu5, GTX 1070, seed=42, epochs=10, weighted recall/precision on val):
-model A → overall 0.324/0.440, night 0.282/0.449; model B → overall **0.415/0.546**, night
-**0.409/0.549**. **B beats A on BOTH val sets with fat margins (+0.09..+0.13)** — large enough to
-survive cross-hardware noise, so the story holds on any machine. Exact numbers reproduce bit-for-bit
-on the **same GPU/CUDA/torch stack** (training determinism is per-hardware); data/splits/tags
-reproduce byte-identically on any machine (seeded canonical cache).
+**Cross-machine numbers:** training is bit-reproducible on one machine (verified: two different
+physical GPUs of the same model → identical metrics), but weights legitimately differ across GPU/CPU models —
+float arithmetic on different chips, not a bug (verified down to byte-identical augmented batches).
+With this config the weighted-F1 spread across seeds (proxy upper bound for machines) is ≤5pp for
+both models on both val sets.
+
+**Deterministic reference** (seed=42, batch=32, epochs=5, freeze=10, thr=0.10, 1000 images;
+weighted F1 / recall on val): model A → overall 0.483/0.348, night 0.408/0.285;
+model B → overall **0.610/0.536**, night **0.551/0.469**. **B beats A on BOTH val sets on every
+seed tested** (F1 margin across seeds 2/7/42: overall +0.081..+0.127, night +0.082..+0.143; per-model
+F1 spread ≤4.6pp). Exact numbers reproduce bit-for-bit on the same GPU/CUDA/torch stack; data/splits/
+tags reproduce byte-identically on any machine (seeded canonical cache). Full cold-start cycle
+(wipe → cache from bucket → load → A → metrics → load → B → metrics → FiftyOne) ≈ 10 min on a
+mid-range GPU.
 
 ## Pre-flight — CHECK what's already there, then ASK (do this before deploying)
 
@@ -150,14 +168,14 @@ pipe** — then stop. Training is **yours to trigger from the datapipe-app front
 
 ```bash
 # SKILL DOES — from examples/detection_tags/detection, with .env sourced:
-python ../scripts/add_request.py --id base-train --n 200 --offset 0   --subset train
-python ../scripts/add_request.py --id base-val   --n 75  --offset 200 --subset val
-python ../scripts/add_request.py --id night-val  --n 75  --offset 275 --subset val --tag night --darken 0.40
-datapipe step --labels=stage=load run                 # 450 images; val frozen (100 base + 25 night)
+python ../scripts/add_request.py --id base-train --n 400 --offset 0   --subset train
+python ../scripts/add_request.py --id base-val   --n 150 --offset 400 --subset val
+python ../scripts/add_request.py --id night-val  --n 150 --offset 550 --subset val --tag night --darken 0.40
+datapipe step --labels=stage=load run                 # 700 images; val frozen (150 base + 150 night)
 
 # VERIFY the data is in the pipe before handing off:
-#   SELECT subset_id, count(*) FROM image__subset_hint GROUP BY subset_id      -- expect train=325, val=125
-#   SELECT count(*) FROM image__ground_truth                                   -- expect 450
+#   SELECT subset_id, count(*) FROM image__subset_hint GROUP BY subset_id      -- expect train=400, val=300
+#   SELECT count(*) FROM image__ground_truth                                   -- expect 700
 ```
 
 **Stop here and hand off.** You now trigger **model-A training from the datapipe-app front** (port
@@ -195,14 +213,14 @@ The skill **tops up** the tagged TRAIN batch and reloads; **you trigger the retr
 
 ```bash
 # SKILL DOES — add the tagged TRAIN batch and load it (val stays frozen):
-python ../scripts/add_request.py --id night-train-a --n 50 --offset 350 --subset train --tag night --darken 0.30
-python ../scripts/add_request.py --id night-train-b --n 50 --offset 400 --subset train --tag night --darken 0.40
-python ../scripts/add_request.py --id night-train-c --n 50 --offset 450 --subset train --tag night --darken 0.55
-datapipe step --labels=stage=load run                 # 500 images total
+python ../scripts/add_request.py --id night-train-a --n 100 --offset 700 --subset train --tag night --darken 0.30
+python ../scripts/add_request.py --id night-train-b --n 100 --offset 800 --subset train --tag night --darken 0.40
+python ../scripts/add_request.py --id night-train-c --n 100 --offset 900 --subset train --tag night --darken 0.55
+datapipe step --labels=stage=load run                 # 1000 images total
 # VERIFY val stayed frozen (night went to TRAIN only):
-#   SELECT h.subset_id, count(*) FROM image__tag it JOIN tag t USING(tag_id)
-#     JOIN image__subset_hint h USING(image_name) WHERE t.tag_name='night' GROUP BY h.subset_id
-#   -- expect train=50, val=25
+#   SELECT h.subset_id, count(*) FROM image__tag t
+#     JOIN image__subset_hint h USING(image_name) WHERE t.tag_id='night' GROUP BY h.subset_id
+#   -- expect train=300, val=150
 ```
 
 **Stop here and hand off — you trigger model-B training from the datapipe-app front** (`stage=train`;
@@ -304,11 +322,22 @@ to a file + `grep`, not inline.
 
 ## Troubleshooting (verify against current files)
 
-- **Building the cache / fresh host** → `python ../scripts/build_cache.py [N]` (default 500) downloads
-  the first N images of the canonical order + writes `gt.json` + `images/`; deterministic — byte-identical
-  on any COCO-reachable machine. Run once, then loads are fast + offline. The cache caps the pool at its
-  size, so keep the batch total ≤ N. NOTE: from RU (e.g. gpu5/Moscow) `images.cocodataset.org` is
-  unreachable — build the cache off-RU and copy `$DATAPIPE_TAGS_CACHE_DIR` (gt.json + images/) to the host.
+- **Getting the cache (fresh host)** → easiest: fetch the pre-built 1000-image cache from the public
+  bucket (no auth, works from RU) into `$DATAPIPE_TAGS_CACHE_DIR`:
+  ```bash
+  BASE=https://storage.yandexcloud.net/e8-demo/datasets/coco-cat-dog-1000
+  mkdir -p "$DATAPIPE_TAGS_CACHE_DIR/images" && cd "$DATAPIPE_TAGS_CACHE_DIR"
+  curl -sf "$BASE/gt.json" -o gt.json
+  python -c "import json; print('\n'.join(json.load(open('gt.json'))))" \
+    | xargs -P 16 -I{} curl -sf -o "images/{}" "$BASE/images/{}"
+  ls images | wc -l   # expect 1000
+  ```
+  Also on the bucket: `datasets/coco-cat-dog-500/` (500-image variant, byte-identical prefix of the
+  same canonical order) and `datasets/coco-annotations/annotations_trainval2017.zip` (raw COCO
+  annotations). Alternative on a COCO-reachable host: `python ../scripts/build_cache.py 1000` —
+  byte-identical result (canonical order; gt.json md5 must match the bucket's). The cache caps the
+  pool at its size, so keep the batch total ≤ N. From RU `images.cocodataset.org` is unreachable —
+  use the bucket.
 - **`SIGILL` / `Illegal instruction` in training** → `polars` built for a newer CPU than the host
   (pre-AVX2). The `polars-lts-cpu` pin isn't enough alone; the regular `polars` comes in transitively.
   After `uv sync`: `uv pip uninstall polars polars-lts-cpu && uv pip install polars-lts-cpu==1.33.1`,

--- a/examples/detection_tags/detection/app.py
+++ b/examples/detection_tags/detection/app.py
@@ -93,7 +93,7 @@ pipeline = Pipeline(
             working_dir=str(DATAPIPE_DIR),
             tmp_folder=datapipe_tmp_folder(),
             yolov8_train_configs=[
-                YoloV8_TrainingConfig(model="yolov8n.pt", imgsz=320, batch=10, epochs=10, exist_ok=True, seed=42, workers=0)
+                YoloV8_TrainingConfig(model="yolov8n.pt", imgsz=320, batch=32, epochs=5, freeze=10, exist_ok=True, seed=42, workers=0)
             ],
             sync_config=TrainingSyncConfig(enabled=True, interval_s=30, retries=3, retry_sleep_s=30),
             resume_config=TrainingResumeConfig(
@@ -113,7 +113,9 @@ pipeline = Pipeline(
             primary_keys=["image_name"],
             bbox_id__name=None,
             image__image_path__name="image_url",
-            batch_size_default=1,
+            batch_size_default=64,
+            chunk_size=1024,
+            prediction_threshold=0.10,
             labels=[("stage", "train"), ("stage", "inference")],
         ),
         CountMetrics_Subset_PipelineModel(
@@ -182,8 +184,8 @@ pipeline = Pipeline(
             inputs=[
                 "local_images",
                 Required("image__ground_truth"),
-                Required("image__subset"),
-                Required("image__tag"),
+                "image__subset",
+                "image__tag",
             ],
             outputs=["fiftyone_annotations"],
             labels=[("stage", "fiftyone")],


### PR DESCRIPTION
## Problem
Demo metrics jumped between runs/machines: the B−A margin could flip sign on an unlucky seed (weighted F1 margin as thin as +0.015), baseline F1 spread was 12-15pp across seeds, and FiftyOne showed ground truth only for tagged images.

## Changes (all config-level, no lib changes)
**Training** (`YoloV8_TrainingConfig`): `batch 10→32` (kills gradient-noise margin flips), `epochs 10→5` (curve still rises at last epoch → best.pt≡last.pt, no epoch-selection jitter), `freeze=10` (frozen backbone — the biggest stability lever).

**Inference** (`Inference_DetectionModel`): `batch_size_default 1→64`, `chunk_size=1024` (full inference pass 71s→36s), `prediction_threshold=0.10` — one fixed operating point for every model/machine instead of per-model `best_threshold`, which jittered between 0.06-0.15 and, by construction (it maximizes F1), flattered the weak baseline.

**Data**: 500→1000 images, same ratios (400 train / 150+150 val / 3×100 night-train γ0.30/0.40/0.55). Pre-built cache is public: `https://storage.yandexcloud.net/e8-demo/datasets/coco-cat-dog-1000/` (fetch commands in the skill; works from RU, no COCO access needed).

**FiftyOne GT fix**: `image__subset`/`image__tag` inputs of `publish_to_fiftyone_ground_truth` were `Required(...)`, so the transform index only covered tagged images — annotations were missing for the rest. Made optional (the func already defaults missing tag/subset to "none"); annotations now cover all 1000 samples.

## Validation (weighted F1 on val, full-pipe cycles)
| seed | A overall / night | B overall / night | Δ overall / night |
|---|---|---|---|
| 42 | 0.483 / 0.408 | 0.610 / 0.551 | +0.127 / +0.143 |
| 2 | 0.518 / 0.425 | 0.599 / 0.507 | +0.081 / +0.082 |
| 7 | 0.512 / 0.427 | 0.624 / 0.553 | +0.112 / +0.126 |

Per-model spread ≤4.6pp on both val sets (was 12-15pp); B beats A on every seed tested (also 0/1 in the stand screening, 130+ training runs total). Same-machine runs reproduce bit-for-bit; cold start (wipe → cache from bucket → both trainings → metrics → FiftyOne) ≈ 10 min on a mid-range GPU.

SKILL.md updated accordingly (recipe, bucket fetch, reference numbers, rationale).